### PR TITLE
#! [euphoria-kafka] Properly quit read loop when interrupted

### DIFF
--- a/euphoria-kafka/src/main/java/cz/seznam/euphoria/kafka/KafkaSource.java
+++ b/euphoria-kafka/src/main/java/cz/seznam/euphoria/kafka/KafkaSource.java
@@ -74,6 +74,12 @@ public class KafkaSource implements DataSource<Pair<byte[], byte[]>> {
     @Override
     protected Pair<byte[], byte[]> computeNext() {
       while (next == null || !next.hasNext()) {
+        if (Thread.currentThread().isInterrupted()) {
+          LOG.info("Terminating polling on topic due to thread interruption");
+          endOfData();
+          return null;
+        }
+
         commitIfNeeded();
         ConsumerRecords<byte[], byte[]> polled = c.poll(500);
         next = polled.iterator();


### PR DESCRIPTION
* Cleans up `KafkaSource` termination upon interruption
* Avoid workaround by involving multiple threads from earlier times
* Resolves the issue 16983 in our original task tracker