### PR TITLE
#! [euphoria-spark] Upgrade to Spark 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -513,7 +513,7 @@
 
   <properties>
     <flink.version>1.1.3</flink.version>
-    <spark.version>2.0.1</spark.version>
+    <spark.version>2.1.0</spark.version>
     <!--
       the guava version used by euphoria; this is
       basically determined by hadoop's provided


### PR DESCRIPTION
No reason to wait with upgrade to the newest Spark. Tried running it with our benchmarks and it worked pretty well.