### PR TITLE
Allow making fast builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,10 +151,6 @@
             <source>1.8</source>
             <target>1.8</target>
             <encoding>UTF-8</encoding>
-            <compilerArgs>
-              <arg>-Xlint:unchecked</arg>
-              <arg>-Werror</arg>
-            </compilerArgs>
           </configuration>
         </plugin>
 
@@ -309,6 +305,22 @@
       </activation>
       <build>
         <plugins>
+          <!-- turn compiler warnings into errors -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.3</version>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+              <encoding>UTF-8</encoding>
+              <compilerArgs>
+                <arg>-Xlint:unchecked</arg>
+                <arg>-Werror</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+
           <!--  generate and attach sources jar -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,7 @@
     </pluginManagement>
 
     <plugins>
+      <!-- require java 8 since that's what euphoria requires -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -278,75 +279,7 @@
         </executions>
       </plugin>
 
-      <!--  generate and attach sources jar -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- generate and attache javadoc jar -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- Plugin fetching information for package manifest meta-data -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>1.3</version>
-        <executions>
-          <execution>
-            <phase>validate</phase>
-            <goals>
-              <goal>create</goal>
-            </goals>
-            <configuration>
-              <doCheck>false</doCheck>
-              <doUpdate>false</doUpdate>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- Plugin fetching information for package manifest meta-data -->
-      <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
-        <version>1.5</version>
-        <executions>
-          <execution>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>execute</goal>
-            </goals>
-            <configuration>
-              <source>
-                project.properties["build.hostname"] = InetAddress.getLocalHost().getHostName()
-              </source>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- generate test reports for Jenkins -->
+      <!-- run tests and generate reports -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -358,76 +291,161 @@
           <argLine>-Xmx512m</argLine>
         </configuration>
       </plugin>
-
-      <!-- produce license resources artifacts/jars -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-remote-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <configuration>
-              <resourceBundles>
-                <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
-              </resourceBundles>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- help managing license headers -->
-      <plugin>
-        <groupId>com.mycila</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <configuration>
-          <header>license-header.txt</header>
-          <properties>
-            <owner>Seznam.cz, a.s.</owner>
-          </properties>
-          <excludes>
-            <exclue>cd/**</exclue>
-            <exclude>**/README</exclude>
-            <exclude>src/test/resources/**</exclude>
-            <exclude>src/main/resources/**</exclude>
-          </excludes>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- static analysis of the code using FindBugs -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.4</version>
-        <configuration>
-          <effort>max</effort>
-          <!-- check only for 'troubling' bugs and worse -->
-          <maxRank>14</maxRank>
-          <xmlOutput>false</xmlOutput>
-          <includeTests>true</includeTests>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>compile</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 
   <profiles>
+    <!--
+      Packages up all the plugins to be executed in "regular" builds. This
+      mainly includes running validations, javadoc and source generation,
+      and prepare stuff for creating a full fledged jar. active by default.
+      You can opt out from this profile to make a very spartan build of the
+      artifacts - may speed up things during local development.
+     -->
+    <profile>
+      <id>regular-build</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <!--  generate and attach sources jar -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- generate and attache javadoc jar -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Plugin fetching information for package manifest meta-data -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>buildnumber-maven-plugin</artifactId>
+            <version>1.3</version>
+            <executions>
+              <execution>
+                <phase>validate</phase>
+                <goals>
+                  <goal>create</goal>
+                </goals>
+                <configuration>
+                  <doCheck>false</doCheck>
+                  <doUpdate>false</doUpdate>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Plugin fetching information for package manifest meta-data -->
+          <plugin>
+            <groupId>org.codehaus.gmaven</groupId>
+            <artifactId>gmaven-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+                <configuration>
+                  <source>
+                    project.properties["build.hostname"] = InetAddress.getLocalHost().getHostName()
+                  </source>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- produce license resources artifacts/jars -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-remote-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>process</goal>
+                </goals>
+                <configuration>
+                  <resourceBundles>
+                    <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
+                  </resourceBundles>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- help managing license headers -->
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <configuration>
+              <header>license-header.txt</header>
+              <properties>
+                <owner>Seznam.cz, a.s.</owner>
+              </properties>
+              <excludes>
+                <exclue>cd/**</exclue>
+                <exclude>**/README</exclude>
+                <exclude>src/test/resources/**</exclude>
+                <exclude>src/main/resources/**</exclude>
+              </excludes>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- static analysis of the code using FindBugs -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+            <version>3.0.4</version>
+            <configuration>
+              <effort>max</effort>
+              <!-- check only for 'troubling' bugs and worse -->
+              <maxRank>14</maxRank>
+              <xmlOutput>false</xmlOutput>
+              <includeTests>true</includeTests>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>compile</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>sign</id>
       <build>


### PR DESCRIPTION
* Moves most maven plugins under the profile "regular-build"
* _"regular-build"_ is active by default
* _"regular-build"_ can be deactivated on the cmdline by `mvn install -P-release-build`
* Resolves #48
