### PR TITLE
#14 [euphoria-flink] Don't send timestamp along with each element.

### DIFF
--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/ExecutionEnvironment.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/ExecutionEnvironment.java
@@ -21,6 +21,8 @@ import cz.seznam.euphoria.core.client.dataset.windowing.Batch;
 import cz.seznam.euphoria.core.client.dataset.windowing.TimeInterval;
 import cz.seznam.euphoria.core.client.flow.Flow;
 import cz.seznam.euphoria.core.client.util.Pair;
+import cz.seznam.euphoria.flink.batch.BatchElement;
+import cz.seznam.euphoria.flink.streaming.StreamingElement;
 import cz.seznam.euphoria.flink.streaming.windowing.KeyedMultiWindowedElement;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -138,7 +140,8 @@ public class ExecutionEnvironment {
     ret.add(TimeInterval.class);
 
     ret.add(Pair.class);
-    ret.add(FlinkElement.class);
+    ret.add(StreamingElement.class);
+    ret.add(BatchElement.class);
     ret.add(KeyedMultiWindowedElement.class);
     return ret;
   }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/FlinkExecutor.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/FlinkExecutor.java
@@ -193,6 +193,10 @@ public class FlinkExecutor implements Executor {
   /**
    * See {@link ExecutionConfig#disableObjectReuse()}
    * and {@link ExecutionConfig#disableObjectReuse()}.
+   *
+   * @param reuse set TRUE for enabling object reuse
+   *
+   * @return this instance (for method chaining purposes)
    */
   public FlinkExecutor setObjectReuse(boolean reuse){
     this.objectReuse = reuse;

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/BatchElement.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/BatchElement.java
@@ -13,28 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package cz.seznam.euphoria.flink;
+package cz.seznam.euphoria.flink.batch;
 
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
 import cz.seznam.euphoria.core.client.dataset.windowing.WindowedElement;
 
 /**
- * Single element flowing through Flink pipeline. Every such element
+ * Single element flowing through Flink batch pipeline. Every such element
  * is associated with a window identifier and timestamp.
  * @param <W> type of the assigned window
  * @param <T> type of the data element
  */
-public class FlinkElement<W extends Window, T> implements WindowedElement<W, T> {
+public class BatchElement<W extends Window, T> implements WindowedElement<W, T> {
 
   private Window window;
   private long timestamp;
   private T element;
 
   // This class needs to ne POJO for effective serialization
-  public FlinkElement() {
+  public BatchElement() {
   }
 
-  public FlinkElement(W window, long timestamp, T element) {
+  public BatchElement(W window, long timestamp, T element) {
     this.window = window;
     this.timestamp = timestamp;
     this.element = element;
@@ -51,20 +51,20 @@ public class FlinkElement<W extends Window, T> implements WindowedElement<W, T> 
   }
 
   @Override
-  public long getTimestamp() {
-    return timestamp;
-  }
-
-  public void setTimestamp(long timestamp) {
-    this.timestamp = timestamp;
-  }
-
-  @Override
   public T getElement() {
     return element;
   }
 
   public void setElement(T element) {
     this.element = element;
+  }
+
+  @Override
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
   }
 }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/BatchUnaryFunctorWrapper.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/BatchUnaryFunctorWrapper.java
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package cz.seznam.euphoria.flink.functions;
+package cz.seznam.euphoria.flink.batch;
 
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
 import cz.seznam.euphoria.core.client.functional.UnaryFunctor;
 import cz.seznam.euphoria.core.client.io.Context;
-import cz.seznam.euphoria.flink.batch.BatchElement;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
@@ -26,14 +25,14 @@ import org.apache.flink.util.Collector;
 
 import java.util.Objects;
 
-public class UnaryFunctorWrapper<WID extends Window, IN, OUT>
+public class BatchUnaryFunctorWrapper<WID extends Window, IN, OUT>
         implements FlatMapFunction<BatchElement<WID, IN>,
         BatchElement<WID, OUT>>,
         ResultTypeQueryable<BatchElement<WID, OUT>> {
 
   private final UnaryFunctor<IN, OUT> f;
 
-  public UnaryFunctorWrapper(UnaryFunctor<IN, OUT> f) {
+  public BatchUnaryFunctorWrapper(UnaryFunctor<IN, OUT> f) {
     this.f = Objects.requireNonNull(f);
   }
 

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/FlatMapTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/FlatMapTranslator.java
@@ -17,7 +17,6 @@ package cz.seznam.euphoria.flink.batch;
 
 import cz.seznam.euphoria.core.client.functional.UnaryFunctor;
 import cz.seznam.euphoria.core.client.operator.FlatMap;
-import cz.seznam.euphoria.flink.FlinkElement;
 import cz.seznam.euphoria.flink.FlinkOperator;
 import cz.seznam.euphoria.flink.functions.UnaryFunctorWrapper;
 import org.apache.flink.api.java.DataSet;
@@ -32,7 +31,7 @@ class FlatMapTranslator implements BatchOperatorTranslator<FlatMap> {
     UnaryFunctor mapper = operator.getOriginalOperator().getFunctor();
     return input
         .flatMap(new UnaryFunctorWrapper<>(mapper))
-        .returns((Class) FlinkElement.class)
+        .returns((Class) BatchElement.class)
         .setParallelism(operator.getParallelism())
         .name(operator.getName());
   }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/FlatMapTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/FlatMapTranslator.java
@@ -18,7 +18,6 @@ package cz.seznam.euphoria.flink.batch;
 import cz.seznam.euphoria.core.client.functional.UnaryFunctor;
 import cz.seznam.euphoria.core.client.operator.FlatMap;
 import cz.seznam.euphoria.flink.FlinkOperator;
-import cz.seznam.euphoria.flink.functions.UnaryFunctorWrapper;
 import org.apache.flink.api.java.DataSet;
 
 class FlatMapTranslator implements BatchOperatorTranslator<FlatMap> {
@@ -30,7 +29,7 @@ class FlatMapTranslator implements BatchOperatorTranslator<FlatMap> {
     DataSet<?> input = context.getSingleInputStream(operator);
     UnaryFunctor mapper = operator.getOriginalOperator().getFunctor();
     return input
-        .flatMap(new UnaryFunctorWrapper<>(mapper))
+        .flatMap(new BatchUnaryFunctorWrapper<>(mapper))
         .returns((Class) BatchElement.class)
         .setParallelism(operator.getParallelism())
         .name(operator.getName());

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/RepartitionTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/RepartitionTranslator.java
@@ -17,7 +17,6 @@ package cz.seznam.euphoria.flink.batch;
 
 import cz.seznam.euphoria.core.client.dataset.partitioning.Partitioning;
 import cz.seznam.euphoria.core.client.operator.Repartition;
-import cz.seznam.euphoria.flink.FlinkElement;
 import cz.seznam.euphoria.flink.FlinkOperator;
 import cz.seznam.euphoria.flink.Utils;
 import cz.seznam.euphoria.flink.functions.PartitionerWrapper;
@@ -30,8 +29,8 @@ class RepartitionTranslator implements BatchOperatorTranslator<Repartition> {
   public DataSet translate(FlinkOperator<Repartition> operator,
       BatchExecutorContext context) {
     
-    DataSet<FlinkElement> input =
-        (DataSet<FlinkElement>)context.getSingleInputStream(operator);
+    DataSet<BatchElement> input =
+        (DataSet<BatchElement>)context.getSingleInputStream(operator);
     
     Partitioning partitioning = operator.getOriginalOperator().getPartitioning();
     PartitionerWrapper flinkPartitioner = 
@@ -39,7 +38,7 @@ class RepartitionTranslator implements BatchOperatorTranslator<Repartition> {
     
     return input.partitionCustom(
             flinkPartitioner,
-            Utils.wrapQueryable((FlinkElement we) -> (Comparable) we.getElement(), Comparable.class))
+            Utils.wrapQueryable((BatchElement we) -> (Comparable) we.getElement(), Comparable.class))
         .setParallelism(operator.getParallelism());
   }
 }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/io/DataSinkWrapper.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/io/DataSinkWrapper.java
@@ -17,14 +17,14 @@ package cz.seznam.euphoria.flink.batch.io;
 
 import cz.seznam.euphoria.core.client.io.DataSink;
 import cz.seznam.euphoria.core.client.io.Writer;
-import cz.seznam.euphoria.flink.FlinkElement;
+import cz.seznam.euphoria.flink.batch.BatchElement;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.configuration.Configuration;
 
 import java.io.IOException;
 
 public class DataSinkWrapper<T>
-    implements OutputFormat<FlinkElement<?, T>>
+    implements OutputFormat<BatchElement<?, T>>
 {
   private final DataSink<T> dataSink;
 
@@ -45,7 +45,7 @@ public class DataSinkWrapper<T>
   }
 
   @Override
-  public void writeRecord(FlinkElement<?, T> record) throws IOException {
+  public void writeRecord(BatchElement<?, T> record) throws IOException {
     writer.write(record.getElement());
   }
 

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/io/DataSourceWrapper.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/io/DataSourceWrapper.java
@@ -20,7 +20,7 @@ import cz.seznam.euphoria.core.client.dataset.windowing.Batch;
 import cz.seznam.euphoria.core.client.io.DataSource;
 import cz.seznam.euphoria.core.client.io.Partition;
 import cz.seznam.euphoria.core.client.io.Reader;
-import cz.seznam.euphoria.flink.FlinkElement;
+import cz.seznam.euphoria.flink.batch.BatchElement;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 
 public class DataSourceWrapper<T>
-        implements InputFormat<FlinkElement<Batch.BatchWindow, T>,
+        implements InputFormat<BatchElement<Batch.BatchWindow, T>,
         PartitionWrapper<T>>,
         ResultTypeQueryable<T> {
 
@@ -92,10 +92,10 @@ public class DataSourceWrapper<T>
   }
 
   @Override
-  public FlinkElement<Batch.BatchWindow, T> nextRecord(
-          FlinkElement<Batch.BatchWindow, T> reuse)
+  public BatchElement<Batch.BatchWindow, T> nextRecord(
+          BatchElement<Batch.BatchWindow, T> reuse)
       throws IOException {
-    return new FlinkElement<>(Batch.BatchWindow.get(), 0L, reader.next());
+    return new BatchElement<>(Batch.BatchWindow.get(), 0L, reader.next());
   }
 
   @Override
@@ -106,6 +106,6 @@ public class DataSourceWrapper<T>
   @Override
   @SuppressWarnings("unchecked")
   public TypeInformation<T> getProducedType() {
-    return TypeInformation.of((Class) FlinkElement.class);
+    return TypeInformation.of((Class) BatchElement.class);
   }
 }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/functions/UnaryFunctorWrapper.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/functions/UnaryFunctorWrapper.java
@@ -18,7 +18,7 @@ package cz.seznam.euphoria.flink.functions;
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
 import cz.seznam.euphoria.core.client.functional.UnaryFunctor;
 import cz.seznam.euphoria.core.client.io.Context;
-import cz.seznam.euphoria.flink.FlinkElement;
+import cz.seznam.euphoria.flink.batch.BatchElement;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
@@ -27,9 +27,9 @@ import org.apache.flink.util.Collector;
 import java.util.Objects;
 
 public class UnaryFunctorWrapper<WID extends Window, IN, OUT>
-        implements FlatMapFunction<FlinkElement<WID, IN>,
-        FlinkElement<WID, OUT>>,
-        ResultTypeQueryable<FlinkElement<WID, OUT>> {
+        implements FlatMapFunction<BatchElement<WID, IN>,
+        BatchElement<WID, OUT>>,
+        ResultTypeQueryable<BatchElement<WID, OUT>> {
 
   private final UnaryFunctor<IN, OUT> f;
 
@@ -38,14 +38,14 @@ public class UnaryFunctorWrapper<WID extends Window, IN, OUT>
   }
 
   @Override
-  public void flatMap(FlinkElement<WID, IN> value,
-                      Collector<FlinkElement<WID, OUT>> out)
+  public void flatMap(BatchElement<WID, IN> value,
+                      Collector<BatchElement<WID, OUT>> out)
       throws Exception
   {
     f.apply(value.getElement(), new Context<OUT>() {
       @Override
       public void collect(OUT elem) {
-        out.collect(new FlinkElement<>(
+        out.collect(new BatchElement<>(
                 value.getWindow(), value.getTimestamp(), elem));
       }
       @Override
@@ -57,7 +57,7 @@ public class UnaryFunctorWrapper<WID extends Window, IN, OUT>
 
   @SuppressWarnings("unchecked")
   @Override
-  public TypeInformation<FlinkElement<WID, OUT>> getProducedType() {
-    return TypeInformation.of((Class) FlinkElement.class);
+  public TypeInformation<BatchElement<WID, OUT>> getProducedType() {
+    return TypeInformation.of((Class) BatchElement.class);
   }
 }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/FlatMapTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/FlatMapTranslator.java
@@ -18,7 +18,6 @@ package cz.seznam.euphoria.flink.streaming;
 import cz.seznam.euphoria.core.client.functional.UnaryFunctor;
 import cz.seznam.euphoria.core.client.operator.FlatMap;
 import cz.seznam.euphoria.flink.FlinkOperator;
-import cz.seznam.euphoria.flink.FlinkElement;
 import org.apache.flink.streaming.api.datastream.DataStream;
 
 class FlatMapTranslator implements StreamingOperatorTranslator<FlatMap> {
@@ -32,7 +31,7 @@ class FlatMapTranslator implements StreamingOperatorTranslator<FlatMap> {
     UnaryFunctor mapper = operator.getOriginalOperator().getFunctor();
     return input
         .flatMap(new StreamingUnaryFunctorWrapper<>(mapper))
-        .returns((Class) FlinkElement.class)
+        .returns((Class) StreamingElement.class)
         .name(operator.getName())
         .setParallelism(operator.getParallelism());
   }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/InputTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/InputTranslator.java
@@ -20,7 +20,6 @@ import cz.seznam.euphoria.core.executor.FlowUnfolder;
 import cz.seznam.euphoria.flink.FlinkOperator;
 import cz.seznam.euphoria.flink.streaming.io.DataSourceWrapper;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.functions.IngestionTimeExtractor;
 
 class InputTranslator implements StreamingOperatorTranslator<FlowUnfolder.InputOperator> {
 
@@ -33,7 +32,6 @@ class InputTranslator implements StreamingOperatorTranslator<FlowUnfolder.InputO
 
     return context.getExecutionEnvironment()
             .addSource(new DataSourceWrapper<>(ds))
-            .setParallelism(operator.getParallelism())
-            .assignTimestampsAndWatermarks(new IngestionTimeExtractor<>());
+            .setParallelism(operator.getParallelism());
   }
 }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/ReduceStateByKeyTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/ReduceStateByKeyTranslator.java
@@ -37,6 +37,7 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
@@ -149,6 +150,9 @@ class ReduceStateByKeyTranslator implements StreamingOperatorTranslator<ReduceSt
 
     private WindowAssignerOperator(WindowAssigner windowAssigner) {
       this.windowAssigner = windowAssigner;
+
+      // allow chaining to optimize performance
+      this.chainingStrategy = ChainingStrategy.ALWAYS;
     }
 
     @Override

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/RepartitionTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/RepartitionTranslator.java
@@ -18,7 +18,6 @@ package cz.seznam.euphoria.flink.streaming;
 import cz.seznam.euphoria.core.client.dataset.partitioning.Partitioning;
 import cz.seznam.euphoria.core.client.operator.Repartition;
 import cz.seznam.euphoria.flink.FlinkOperator;
-import cz.seznam.euphoria.flink.FlinkElement;
 import cz.seznam.euphoria.flink.functions.PartitionerWrapper;
 import org.apache.flink.streaming.api.datastream.DataStream;
 
@@ -29,8 +28,8 @@ class RepartitionTranslator implements StreamingOperatorTranslator<Repartition> 
   public DataStream<?> translate(FlinkOperator<Repartition> operator,
                                  StreamingExecutorContext context)
   {
-    DataStream<FlinkElement> input =
-        (DataStream<FlinkElement>) context.getSingleInputStream(operator);
+    DataStream<StreamingElement> input =
+        (DataStream<StreamingElement>) context.getSingleInputStream(operator);
     Partitioning partitioning = operator.getOriginalOperator().getPartitioning();
 
     PartitionerWrapper flinkPartitioner =

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/StreamingElement.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/StreamingElement.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2016 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.flink.streaming;
+
+import cz.seznam.euphoria.core.client.dataset.windowing.Window;
+
+/**
+ * Single element flowing through Flink streaming pipeline. Every such element
+ * is associated with a window identifier and timestamp.
+ * @param <W> type of the assigned window
+ * @param <T> type of the data element
+ */
+public class StreamingElement<W extends Window, T> {
+
+  private Window window;
+  private T element;
+
+  // This class needs to ne POJO for effective serialization
+  public StreamingElement() {
+  }
+
+  public StreamingElement(W window, T element) {
+    this.window = window;
+    this.element = element;
+  }
+
+  @SuppressWarnings("unchecked")
+  public W getWindow() {
+    return (W) window;
+  }
+
+  public void setWindow(W window) {
+    this.window = window;
+  }
+
+  public T getElement() {
+    return element;
+  }
+
+  public void setElement(T element) {
+    this.element = element;
+  }
+}

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/StreamingFlowTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/StreamingFlowTranslator.java
@@ -84,8 +84,8 @@ public class StreamingFlowTranslator extends FlowTranslator {
     // transform flow to acyclic graph of supported operators
     DAG<FlinkOperator<Operator<?, ?>>> dag = flowToDag(flow);
 
-    // we're running exclusively on event time
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+    // we're running exclusively on ingestion time
+    env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime);
     env.getConfig().setAutoWatermarkInterval(autoWatermarkInterval.toMillis());
 
     StreamingExecutorContext executorContext =

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/StreamingUnaryFunctorWrapper.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/StreamingUnaryFunctorWrapper.java
@@ -18,7 +18,6 @@ package cz.seznam.euphoria.flink.streaming;
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
 import cz.seznam.euphoria.core.client.functional.UnaryFunctor;
 import cz.seznam.euphoria.core.client.io.Context;
-import cz.seznam.euphoria.flink.FlinkElement;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
@@ -27,9 +26,9 @@ import org.apache.flink.util.Collector;
 import java.util.Objects;
 
 public class StreamingUnaryFunctorWrapper<WID extends Window, IN, OUT>
-        implements FlatMapFunction<FlinkElement<WID, IN>,
-        FlinkElement<WID, OUT>>,
-        ResultTypeQueryable<FlinkElement<WID, OUT>> {
+        implements FlatMapFunction<StreamingElement<WID, IN>,
+        StreamingElement<WID, OUT>>,
+        ResultTypeQueryable<StreamingElement<WID, OUT>> {
 
   private final UnaryFunctor<IN, OUT> f;
 
@@ -38,26 +37,25 @@ public class StreamingUnaryFunctorWrapper<WID extends Window, IN, OUT>
   }
 
   @Override
-  public void flatMap(FlinkElement<WID, IN> value,
-                      Collector<FlinkElement<WID, OUT>> out)
+  public void flatMap(StreamingElement<WID, IN> element,
+                      Collector<StreamingElement<WID, OUT>> out)
       throws Exception
   {
-    f.apply(value.getElement(), new Context<OUT>() {
+    f.apply(element.getElement(), new Context<OUT>() {
       @Override
       public void collect(OUT elem) {
-        out.collect(new FlinkElement<>(
-                value.getWindow(), value.getTimestamp(), elem));
+        out.collect(new StreamingElement<>(element.getWindow(), elem));
       }
       @Override
       public Object getWindow() {
-        return value.getWindow();
+        return element.getWindow();
       }
     });
   }
 
   @SuppressWarnings("unchecked")
   @Override
-  public TypeInformation<FlinkElement<WID, OUT>> getProducedType() {
-    return TypeInformation.of((Class) FlinkElement.class);
+  public TypeInformation<StreamingElement<WID, OUT>> getProducedType() {
+    return TypeInformation.of((Class) StreamingElement.class);
   }
 }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/io/DataSinkWrapper.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/io/DataSinkWrapper.java
@@ -17,7 +17,7 @@ package cz.seznam.euphoria.flink.streaming.io;
 
 import cz.seznam.euphoria.core.client.io.DataSink;
 import cz.seznam.euphoria.core.client.io.Writer;
-import cz.seznam.euphoria.flink.FlinkElement;
+import cz.seznam.euphoria.flink.streaming.StreamingElement;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import java.io.Serializable;
 
 public class DataSinkWrapper<T>
-    extends RichSinkFunction<FlinkElement<?, T>>
+    extends RichSinkFunction<StreamingElement<?, T>>
     implements Checkpointed {
 
   private DataSink<T> dataSink;
@@ -56,7 +56,7 @@ public class DataSinkWrapper<T>
   }
 
   @Override
-  public void invoke(FlinkElement<?, T> elem) throws Exception {
+  public void invoke(StreamingElement<?, T> elem) throws Exception {
     writer.write(elem.getElement());
   }
 

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/io/DataSourceWrapper.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/io/DataSourceWrapper.java
@@ -20,7 +20,7 @@ import cz.seznam.euphoria.core.client.dataset.windowing.Batch;
 import cz.seznam.euphoria.core.client.io.DataSource;
 import cz.seznam.euphoria.core.client.io.Partition;
 import cz.seznam.euphoria.core.client.io.Reader;
-import cz.seznam.euphoria.flink.FlinkElement;
+import cz.seznam.euphoria.flink.streaming.StreamingElement;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
@@ -36,8 +36,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class DataSourceWrapper<T>
-        extends RichParallelSourceFunction<FlinkElement<Batch.BatchWindow, T>>
-        implements ResultTypeQueryable<FlinkElement<Batch.BatchWindow, T>>
+        extends RichParallelSourceFunction<StreamingElement<Batch.BatchWindow, T>>
+        implements ResultTypeQueryable<StreamingElement<Batch.BatchWindow, T>>
 {
   private final DataSource<T> dataSource;
   private volatile boolean isRunning = true;
@@ -49,7 +49,7 @@ public class DataSourceWrapper<T>
   }
 
   @Override
-  public void run(SourceContext<FlinkElement<Batch.BatchWindow, T>> ctx)
+  public void run(SourceContext<StreamingElement<Batch.BatchWindow, T>> ctx)
       throws Exception {
     StreamingRuntimeContext runtimeContext =
             (StreamingRuntimeContext) getRuntimeContext();
@@ -106,9 +106,9 @@ public class DataSourceWrapper<T>
     }
   }
 
-  private FlinkElement<Batch.BatchWindow, T> toStreamingElement(T elem) {
+  private StreamingElement<Batch.BatchWindow, T> toStreamingElement(T elem) {
     // assign ingestion timestamp to elements
-    return new FlinkElement<>(Batch.BatchWindow.get(), System.currentTimeMillis(), elem);
+    return new StreamingElement<>(Batch.BatchWindow.get(), elem);
   }
 
   @Override
@@ -121,8 +121,8 @@ public class DataSourceWrapper<T>
 
   @Override
   @SuppressWarnings("unchecked")
-  public TypeInformation<FlinkElement<Batch.BatchWindow, T>> getProducedType() {
-    return TypeInformation.of((Class) FlinkElement.class);
+  public TypeInformation<StreamingElement<Batch.BatchWindow, T>> getProducedType() {
+    return TypeInformation.of((Class) StreamingElement.class);
   }
 
   private ThreadPoolExecutor createThreadPool() {

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/KeyedMultiWindowedElement.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/KeyedMultiWindowedElement.java
@@ -16,14 +16,14 @@
 package cz.seznam.euphoria.flink.streaming.windowing;
 
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
-import cz.seznam.euphoria.flink.FlinkElement;
+import cz.seznam.euphoria.flink.streaming.StreamingElement;
 
 import java.util.Set;
 
 /**
  * Single data element associated with multiple windows. It's rather used
  * for performance optimization as the same thing could be expressed
- * as a set of {@link FlinkElement} instances.
+ * as a set of {@link StreamingElement} instances.
  *
  * @param <WID>   Type of used window
  * @param <KEY>   Type of element's key
@@ -33,7 +33,6 @@ public class KeyedMultiWindowedElement<WID extends Window, KEY, VALUE> {
 
   private KEY key;
   private VALUE value;
-  private long timestamp;
   private Set<WID> windows;
 
   public KeyedMultiWindowedElement() {
@@ -41,11 +40,9 @@ public class KeyedMultiWindowedElement<WID extends Window, KEY, VALUE> {
 
   public KeyedMultiWindowedElement(KEY key,
                                    VALUE value,
-                                   long timestamp,
                                    Set<WID> windows) {
     this.key = key;
     this.value = value;
-    this.timestamp = timestamp;
     this.windows = windows;
   }
 
@@ -63,14 +60,6 @@ public class KeyedMultiWindowedElement<WID extends Window, KEY, VALUE> {
 
   public void setValue(VALUE value) {
     this.value = value;
-  }
-
-  public long getTimestamp() {
-    return timestamp;
-  }
-
-  public void setTimestamp(long timestamp) {
-    this.timestamp = timestamp;
   }
 
   public Set<WID> getWindows() {

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/WindowAssigner.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/WindowAssigner.java
@@ -61,7 +61,7 @@ public class WindowAssigner<I, KEY, VALUE, W extends Window>
       reuse = new TimestampedElement();
     }
     reuse.setTimestamp(record.getTimestamp());
-    reuse.setElement(el);
+    reuse.setStreamingElement(el);
     Set windows = windowing.assignWindowsToElement(reuse);
 
     return new KeyedMultiWindowedElement<>(
@@ -76,9 +76,6 @@ public class WindowAssigner<I, KEY, VALUE, W extends Window>
     private long timestamp;
     private StreamingElement<W, T> element;
 
-    public TimestampedElement() {
-    }
-
     @Override
     public W getWindow() {
       return element.getWindow();
@@ -89,7 +86,7 @@ public class WindowAssigner<I, KEY, VALUE, W extends Window>
       return timestamp;
     }
 
-    public void setTimestamp(long timestamp) {
+    private void setTimestamp(long timestamp) {
       this.timestamp = timestamp;
     }
 
@@ -98,7 +95,7 @@ public class WindowAssigner<I, KEY, VALUE, W extends Window>
       return element.getElement();
     }
 
-    public void setElement(StreamingElement<W, T> element) {
+    private void setStreamingElement(StreamingElement<W, T> element) {
       this.element = element;
     }
   }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/WindowAssigner.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/WindowAssigner.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2016 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.flink.streaming.windowing;
+
+import cz.seznam.euphoria.core.client.dataset.windowing.Window;
+import cz.seznam.euphoria.core.client.dataset.windowing.WindowedElement;
+import cz.seznam.euphoria.core.client.dataset.windowing.Windowing;
+import cz.seznam.euphoria.core.client.functional.UnaryFunction;
+import cz.seznam.euphoria.flink.streaming.StreamingElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.Serializable;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Assigns windows to element and extracts key and value.
+ *
+ * @param <I>     type of input data
+ * @param <KEY>   type of output key
+ * @param <VALUE> type of output value
+ * @param <W>     type of output window
+ */
+public class WindowAssigner<I, KEY, VALUE, W extends Window>
+        implements Function<StreamRecord<StreamingElement<?, I>>, KeyedMultiWindowedElement<W, KEY, VALUE>>,
+        Serializable {
+
+  private final Windowing windowing;
+  private final UnaryFunction keyExtractor;
+  private final UnaryFunction valueExtractor;
+
+  private transient TimestampedElement reuse;
+
+  public WindowAssigner(Windowing windowing,
+                        UnaryFunction keyExtractor,
+                        UnaryFunction valueExtractor) {
+    this.windowing = windowing;
+    this.keyExtractor = keyExtractor;
+    this.valueExtractor = valueExtractor;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public KeyedMultiWindowedElement<W, KEY, VALUE> apply(StreamRecord<StreamingElement<?, I>> record) {
+    StreamingElement el = record.getValue();
+
+    if (reuse == null) {
+      reuse = new TimestampedElement();
+    }
+    reuse.setTimestamp(record.getTimestamp());
+    reuse.setElement(el);
+    Set windows = windowing.assignWindowsToElement(reuse);
+
+    return new KeyedMultiWindowedElement<>(
+            keyExtractor.apply(el.getElement()),
+            valueExtractor.apply(el.getElement()),
+            windows);
+  }
+
+  private static class TimestampedElement<W extends Window, T>
+          implements WindowedElement<W, T> {
+
+    private long timestamp;
+    private StreamingElement<W, T> element;
+
+    public TimestampedElement() {
+    }
+
+    @Override
+    public W getWindow() {
+      return element.getWindow();
+    }
+
+    @Override
+    public long getTimestamp() {
+      return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+      this.timestamp = timestamp;
+    }
+
+    @Override
+    public T getElement() {
+      return element.getElement();
+    }
+
+    public void setElement(StreamingElement<W, T> element) {
+      this.element = element;
+    }
+  }
+}

--- a/euphoria-flink/src/test/java/cz/seznam/euphoria/flink/batch/BatchElementTest.java
+++ b/euphoria-flink/src/test/java/cz/seznam/euphoria/flink/batch/BatchElementTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.flink.batch;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.runtime.PojoSerializer;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BatchElementTest {
+
+  @Test
+  public void testSerializer() {
+    TypeSerializer<BatchElement> serializer =
+            TypeInformation.of(BatchElement.class)
+                    .createSerializer(new ExecutionConfig());
+
+    // must be POJO serializer for performance reasons
+    assertTrue(serializer instanceof PojoSerializer);
+  }
+}

--- a/euphoria-flink/src/test/java/cz/seznam/euphoria/flink/streaming/StreamingElementTest.java
+++ b/euphoria-flink/src/test/java/cz/seznam/euphoria/flink/streaming/StreamingElementTest.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package cz.seznam.euphoria.flink;
+package cz.seznam.euphoria.flink.streaming;
 
+import cz.seznam.euphoria.flink.streaming.StreamingElement;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -23,12 +24,12 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class FlinkElementTest {
+public class StreamingElementTest {
 
   @Test
   public void testSerializer() {
-    TypeSerializer<FlinkElement> serializer =
-            TypeInformation.of(FlinkElement.class)
+    TypeSerializer<StreamingElement> serializer =
+            TypeInformation.of(StreamingElement.class)
                     .createSerializer(new ExecutionConfig());
 
     // must be POJO serializer for performance reasons


### PR DESCRIPTION
In Flink streaming executor a timestamp is not sent with each element anymore. Instead it relies on internal Flink timestamps.

Seems it introduces noticeable performance benefits.