### PR TITLE
#47 TimeSliding window assigner generates custom SlidingWindowSet

### DIFF
--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Batch.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Batch.java
@@ -20,7 +20,6 @@ import cz.seznam.euphoria.core.client.triggers.Trigger;
 
 import java.io.ObjectStreamException;
 import java.util.Collections;
-import java.util.Set;
 
 /**
  * Windowing with single window across the whole dataset. Suitable for
@@ -60,7 +59,7 @@ public final class Batch<T>
   private Batch() {}
 
   @Override
-  public Set<BatchWindow> assignWindowsToElement(WindowedElement<?, T> el) {
+  public Iterable<BatchWindow> assignWindowsToElement(WindowedElement<?, T> el) {
     return Collections.singleton(BatchWindow.INSTANCE);
   }
 

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Count.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Count.java
@@ -18,8 +18,6 @@ package cz.seznam.euphoria.core.client.dataset.windowing;
 import cz.seznam.euphoria.core.client.triggers.CountTrigger;
 import cz.seznam.euphoria.core.client.triggers.Trigger;
 
-import java.util.Set;
-
 import static java.util.Collections.singleton;
 
 /**
@@ -34,7 +32,7 @@ public final class Count<T> implements Windowing<T, Batch.BatchWindow> {
   }
 
   @Override
-  public Set<Batch.BatchWindow> assignWindowsToElement(WindowedElement<?, T> el) {
+  public Iterable<Batch.BatchWindow> assignWindowsToElement(WindowedElement<?, T> el) {
     return singleton(Batch.BatchWindow.get());
   }
 

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Session.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Session.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Session windowing.
@@ -69,7 +68,7 @@ public final class Session<T> implements MergingWindowing<T, TimeInterval> {
   }
 
   @Override
-  public Set<TimeInterval> assignWindowsToElement(WindowedElement<?, T> el) {
+  public Iterable<TimeInterval> assignWindowsToElement(WindowedElement<?, T> el) {
     long stamp = el.getTimestamp();
     TimeInterval ret = new TimeInterval(stamp, stamp + gapDurationMillis);
     return Collections.singleton(ret);

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Time.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Time.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Set;
 
 import static java.util.Collections.singleton;
 
@@ -65,7 +64,7 @@ public class Time<T> implements Windowing<T, TimeInterval> {
   }
 
   @Override
-  public Set<TimeInterval> assignWindowsToElement(WindowedElement<?, T> el) {
+  public Iterable<TimeInterval> assignWindowsToElement(WindowedElement<?, T> el) {
     long stamp = el.getTimestamp();
     long start = stamp - (stamp + durationMillis) % durationMillis;
     long end = start + durationMillis;

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/TimeSliding.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/TimeSliding.java
@@ -64,7 +64,7 @@ public final class TimeSliding<T>
   }
 
   @Override
-  public Set<TimeInterval> assignWindowsToElement(WindowedElement<?, T> el) {
+  public Iterable<TimeInterval> assignWindowsToElement(WindowedElement<?, T> el) {
     Set<TimeInterval> ret =
             Sets.newHashSetWithExpectedSize((int) (this.duration / this.slide));
     for (long start = el.getTimestamp() - el.getTimestamp() % this.slide;

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Windowing.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Windowing.java
@@ -18,7 +18,6 @@ package cz.seznam.euphoria.core.client.dataset.windowing;
 import cz.seznam.euphoria.core.client.triggers.Trigger;
 
 import java.io.Serializable;
-import java.util.Set;
 
 
 /**
@@ -35,9 +34,9 @@ public interface Windowing<T, W extends Window> extends Serializable {
    *
    * @param el The element to which windows should be assigned.
    *
-   * @return set of windows to be assign this element into, never {@code null}.
+   * @return collection of windows to be assigned this element into, never {@code null}.
    */
-  Set<W> assignWindowsToElement(WindowedElement<?, T> el);
+  Iterable<W> assignWindowsToElement(WindowedElement<?, T> el);
 
   /**
    * @return a {@link Trigger} associated with the current windowing strategy

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/dataset/windowing/SessionTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/dataset/windowing/SessionTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2016 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.core.client.dataset.windowing;
+
+import com.google.common.collect.Iterables;
+import cz.seznam.euphoria.core.client.util.Pair;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+public class SessionTest {
+
+  @Test
+  public void testWindowAssignment() {
+    Session<?> windowing = Session.of(Duration.ofMillis(10));
+
+    Iterable<TimeInterval> windows =
+            windowing.assignWindowsToElement(new TimestampedElement<>(13));
+    assertEquals(1, Iterables.size(windows));
+    assertEquals(new TimeInterval(13, 23), Iterables.getOnlyElement(windows));
+  }
+
+  @Test
+  public void testWindowMerging() {
+    Session<?> windowing = Session.of(Duration.ofMillis(10));
+
+    Collection<Pair<Collection<TimeInterval>, TimeInterval>> merged =
+            windowing.mergeWindows(Arrays.asList(
+                    new TimeInterval(5, 15),
+                    new TimeInterval(12, 22)));
+
+    assertEquals(1, merged.size());
+    assertEquals(new TimeInterval(5, 22), Iterables.getOnlyElement(merged).getSecond());
+
+    Collection<Pair<Collection<TimeInterval>, TimeInterval>> nonMerged =
+            windowing.mergeWindows(Arrays.asList(
+                    new TimeInterval(5, 15),
+                    new TimeInterval(16, 22)));
+
+    assertTrue(nonMerged.isEmpty());
+  }
+}

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/dataset/windowing/TimeSlidingTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/dataset/windowing/TimeSlidingTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2016 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.core.client.dataset.windowing;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.*;
+
+public class TimeSlidingTest {
+
+  @Test
+  public void testWindowAssignment() {
+    TimeSliding<?> windowing =
+            TimeSliding.of(Duration.ofMillis(10), Duration.ofMillis(5));
+
+    Iterable<TimeInterval> windows =
+            windowing.assignWindowsToElement(new TimestampedElement<>(16));
+
+    assertEquals(2, Iterables.size(windows));
+    assertEquals(Sets.newHashSet(
+            new TimeInterval(10, 20),
+            new TimeInterval(15, 25)),
+            Sets.newHashSet(windows));
+
+    windows = windowing.assignWindowsToElement(new TimestampedElement<>(10));
+
+    assertEquals(2, Iterables.size(windows));
+    assertEquals(Sets.newHashSet(
+            new TimeInterval(5, 15),
+            new TimeInterval(10, 20)),
+            Sets.newHashSet(windows));
+
+    windows = windowing.assignWindowsToElement(new TimestampedElement<>(9));
+
+    assertEquals(2, Iterables.size(windows));
+    assertEquals(Sets.newHashSet(
+            new TimeInterval(0, 10),
+            new TimeInterval(5, 15)),
+            Sets.newHashSet(windows));
+  }
+}

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/dataset/windowing/TimeTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/dataset/windowing/TimeTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.core.client.dataset.windowing;
+
+import com.google.common.collect.Iterables;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.*;
+
+public class TimeTest {
+
+  @Test
+  public void testWindowAssignment() {
+    Time<?> windowing = Time.of(Duration.ofMillis(10));
+
+    Iterable<TimeInterval> windows =
+            windowing.assignWindowsToElement(new TimestampedElement<>(11));
+
+    assertEquals(1, Iterables.size(windows));
+    assertEquals(new TimeInterval(10, 20), Iterables.getOnlyElement(windows));
+
+    windows = windowing.assignWindowsToElement(new TimestampedElement<>(10));
+    assertEquals(1, Iterables.size(windows));
+    assertEquals(new TimeInterval(10, 20), Iterables.getOnlyElement(windows));
+
+    windows = windowing.assignWindowsToElement(new TimestampedElement<>(9));
+    assertEquals(1, Iterables.size(windows));
+    assertEquals(new TimeInterval(0, 10), Iterables.getOnlyElement(windows));
+  }
+
+}

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/dataset/windowing/TimestampedElement.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/dataset/windowing/TimestampedElement.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.core.client.dataset.windowing;
+
+class TimestampedElement<W extends Window, T> implements WindowedElement<W, T> {
+
+  private final long timestamp;
+
+  public TimestampedElement(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  @Override
+  public W getWindow() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public T getElement() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/dataset/windowing/WindowingTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/dataset/windowing/WindowingTest.java
@@ -69,7 +69,7 @@ public class WindowingTest {
     assertEquals(expectDurationMillis, w.getDuration());
   }
 
-  <W extends Window, T> Set<W> assignWindows(Windowing<T, W> windowing,
+  <W extends Window, T> Iterable<W> assignWindows(Windowing<T, W> windowing,
                                              T elem,
                                              UnaryFunction<T, Long> eventTimeAssigner) {
     return windowing.assignWindowsToElement(
@@ -109,7 +109,7 @@ public class WindowingTest {
   }
 
   private TimeInterval assertSessionWindow(
-      Set<TimeInterval> window, long expectedStartMillis, long expectedEndMillis) {
+      Iterable<TimeInterval> window, long expectedStartMillis, long expectedEndMillis) {
     TimeInterval w = Iterables.getOnlyElement(window);
     assertSessionWindow(w, expectedStartMillis, expectedEndMillis);
     return w;
@@ -143,11 +143,11 @@ public class WindowingTest {
     };
 
     for (long event : data) {
-      Set<TimeInterval> labels = windowing
+      Iterable<TimeInterval> labels = windowing
           .assignWindowsToElement(new Elem<>(
               Batch.BatchWindow.get(), event, eventTimeAssigner.apply(event)));
       // verify window count
-      assertEquals(3, labels.size());
+      assertEquals(3, Iterables.size(labels));
       // verify that each window contains the original event
       for (TimeInterval l : labels) {
         long stamp = event * 1000L;

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/ExecutionEnvironment.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/ExecutionEnvironment.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Sets;
 import cz.seznam.euphoria.core.client.dataset.Dataset;
 import cz.seznam.euphoria.core.client.dataset.windowing.Batch;
 import cz.seznam.euphoria.core.client.dataset.windowing.TimeInterval;
+import cz.seznam.euphoria.core.client.dataset.windowing.TimeSliding;
 import cz.seznam.euphoria.core.client.flow.Flow;
 import cz.seznam.euphoria.core.client.util.Either;
 import cz.seznam.euphoria.core.client.util.Pair;
@@ -140,6 +141,7 @@ public class ExecutionEnvironment {
     // register all types of used windows
     ret.add(Batch.BatchWindow.class);
     ret.add(TimeInterval.class);
+    ret.add(TimeSliding.SlidingWindowSet.class);
 
     ret.add(Either.class);
     ret.add(Pair.class);

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/AttachedWindowing.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/AttachedWindowing.java
@@ -22,7 +22,6 @@ import cz.seznam.euphoria.core.client.triggers.NoopTrigger;
 import cz.seznam.euphoria.core.client.triggers.Trigger;
 
 import java.util.Collections;
-import java.util.Set;
 
 class AttachedWindowing<T, W extends Window> implements Windowing<T, W> {
 
@@ -30,7 +29,7 @@ class AttachedWindowing<T, W extends Window> implements Windowing<T, W> {
 
   @Override
   @SuppressWarnings("unchecked")
-  public Set<W> assignWindowsToElement(WindowedElement<?, T> input) {
+  public Iterable<W> assignWindowsToElement(WindowedElement<?, T> input) {
     return Collections.singleton((W) input.getWindow());
   }
 

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceByKeyTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceByKeyTranslator.java
@@ -90,7 +90,7 @@ public class ReduceByKeyTranslator implements BatchOperatorTranslator<ReduceByKe
               long stamp = timeAssigner.extractTimestamp(wel.getElement());
               wel.setTimestamp(stamp);
             }
-            Set<Window> assigned = windowing.assignWindowsToElement(wel);
+            Iterable<Window> assigned = windowing.assignWindowsToElement(wel);
             for (Window wid : assigned) {
               Object el = wel.getElement();
               long stamp = (wid instanceof TimedWindow)

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceStateByKeyTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceStateByKeyTranslator.java
@@ -82,7 +82,7 @@ public class ReduceStateByKeyTranslator implements BatchOperatorTranslator<Reduc
               if (timeAssigner != null) {
                 wel.setTimestamp(timeAssigner.extractTimestamp(wel.getElement()));
               }
-              Set<Window> assigned = windowing.assignWindowsToElement(wel);
+              Iterable<Window> assigned = windowing.assignWindowsToElement(wel);
               for (Window wid : assigned) {
                 Object el = wel.getElement();
                 c.collect(new BatchElement<>(

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/AttachedWindowing.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/AttachedWindowing.java
@@ -23,13 +23,12 @@ import cz.seznam.euphoria.core.client.triggers.Trigger;
 import cz.seznam.euphoria.core.client.triggers.TriggerContext;
 
 import java.util.Collections;
-import java.util.Set;
 
 public class AttachedWindowing<T, WID extends Window> implements Windowing<T, WID> {
 
   @Override
   @SuppressWarnings("unchecked")
-  public Set<WID> assignWindowsToElement(WindowedElement<?, T> el) {
+  public Iterable<WID> assignWindowsToElement(WindowedElement<?, T> el) {
     return Collections.singleton((WID) el.getWindow());
   }
 

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/KeyedMultiWindowedElement.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/KeyedMultiWindowedElement.java
@@ -33,14 +33,14 @@ public class KeyedMultiWindowedElement<WID extends Window, KEY, VALUE> {
 
   private KEY key;
   private VALUE value;
-  private Set<WID> windows;
+  private Iterable<WID> windows;
 
   public KeyedMultiWindowedElement() {
   }
 
   public KeyedMultiWindowedElement(KEY key,
                                    VALUE value,
-                                   Set<WID> windows) {
+                                   Iterable<WID> windows) {
     this.key = key;
     this.value = value;
     this.windows = windows;
@@ -62,11 +62,11 @@ public class KeyedMultiWindowedElement<WID extends Window, KEY, VALUE> {
     this.value = value;
   }
 
-  public Set<WID> getWindows() {
+  public Iterable<WID> getWindows() {
     return windows;
   }
 
-  public void setWindows(Set<WID> windows) {
+  public void setWindows(Iterable<WID> windows) {
     this.windows = windows;
   }
 }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/WindowAssigner.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/WindowAssigner.java
@@ -23,7 +23,6 @@ import cz.seznam.euphoria.flink.streaming.StreamingElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import java.io.Serializable;
-import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -62,7 +61,7 @@ public class WindowAssigner<I, KEY, VALUE, W extends Window>
     }
     reuse.setTimestamp(record.getTimestamp());
     reuse.setStreamingElement(el);
-    Set windows = windowing.assignWindowsToElement(reuse);
+    Iterable windows = windowing.assignWindowsToElement(reuse);
 
     return new KeyedMultiWindowedElement<>(
             keyExtractor.apply(el.getElement()),

--- a/euphoria-inmem/src/main/java/cz/seznam/euphoria/inmem/AttachedWindowing.java
+++ b/euphoria-inmem/src/main/java/cz/seznam/euphoria/inmem/AttachedWindowing.java
@@ -22,7 +22,6 @@ import cz.seznam.euphoria.core.client.triggers.NoopTrigger;
 import cz.seznam.euphoria.core.client.triggers.Trigger;
 
 import java.util.Collections;
-import java.util.Set;
 
 class AttachedWindowing<T, W extends Window> implements Windowing<T, W> {
 
@@ -30,7 +29,7 @@ class AttachedWindowing<T, W extends Window> implements Windowing<T, W> {
 
   @SuppressWarnings("unchecked")
   @Override
-  public Set<W> assignWindowsToElement(WindowedElement<?, T> input) {
+  public Iterable<W> assignWindowsToElement(WindowedElement<?, T> input) {
     return Collections.singleton((W) input.getWindow());
   }
 

--- a/euphoria-inmem/src/main/java/cz/seznam/euphoria/inmem/InMemExecutor.java
+++ b/euphoria-inmem/src/main/java/cz/seznam/euphoria/inmem/InMemExecutor.java
@@ -712,7 +712,7 @@ public class InMemExecutor implements Executor {
                   (oldVal, newVal) -> oldVal < newVal ? newVal : oldVal);
               // determine partition
               Object key = keyExtractor.apply(datum.getElement());
-              final Set<Window> targetWindows;
+              final Iterable<Window> targetWindows;
               int windowShift = 0;
               if (allowWindowBasedShuffling) {
                 if (windowing.isPresent()) {
@@ -723,7 +723,7 @@ public class InMemExecutor implements Executor {
                   targetWindows = Collections.singleton(datum.getWindow());
                 }
 
-                if (!isMergingWindowing && targetWindows.size() == 1) {
+                if (!isMergingWindowing && Iterables.size(targetWindows) == 1) {
                   windowShift = new Random(
                       Iterables.getOnlyElement(targetWindows).hashCode()).nextInt();
                 }

--- a/euphoria-inmem/src/main/java/cz/seznam/euphoria/inmem/ReduceStateByKeyReducer.java
+++ b/euphoria-inmem/src/main/java/cz/seznam/euphoria/inmem/ReduceStateByKeyReducer.java
@@ -735,7 +735,7 @@ class ReduceStateByKeyReducer implements Runnable {
     Object itemKey = keyExtractor.apply(item);
     Object itemValue = valueExtractor.apply(item);
 
-    Set<Window> windows = windowing.assignWindowsToElement(element);
+    Iterable<Window> windows = windowing.assignWindowsToElement(element);
     for (Window window : windows) {
       ElementTriggerContext pitctx =
           new ElementTriggerContext(new KeyedWindow(window, itemKey));
@@ -757,7 +757,7 @@ class ReduceStateByKeyReducer implements Runnable {
     Object itemKey = keyExtractor.apply(item);
     Object itemValue = valueExtractor.apply(item);
 
-    Set<Window> windows = windowing.assignWindowsToElement(element);
+    Iterable<Window> windows = windowing.assignWindowsToElement(element);
     for (Window window : windows) {
 
       // ~ first try to merge the new window into the set of existing ones

--- a/euphoria-inmem/src/test/java/cz/seznam/euphoria/inmem/InMemExecutorTest.java
+++ b/euphoria-inmem/src/test/java/cz/seznam/euphoria/inmem/InMemExecutorTest.java
@@ -356,7 +356,7 @@ public class InMemExecutorTest {
     }
 
     @Override
-    public Set<SizedCountWindow> assignWindowsToElement(WindowedElement<?, T> input) {
+    public Iterable<SizedCountWindow> assignWindowsToElement(WindowedElement<?, T> input) {
       int sz = size.apply(input.getElement());
       return Sets.newHashSet(new SizedCountWindow(sz), new SizedCountWindow(2 * sz));
     }

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/JoinTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/JoinTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
@@ -169,7 +168,7 @@ public class JoinTest extends AbstractOperatorTest {
       implements Windowing<Either<Integer, Long>, IntWindow> {
 
     @Override
-    public Set<IntWindow> assignWindowsToElement(
+    public Iterable<IntWindow> assignWindowsToElement(
         WindowedElement<?, Either<Integer, Long>> input) {
       int element;
       Either<Integer, Long> unwrapped = input.getElement();

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceByKeyTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceByKeyTest.java
@@ -58,7 +58,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -179,7 +178,7 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
 
   static class TestWindowing implements Windowing<Integer, IntWindow> {
     @Override
-    public Set<IntWindow> assignWindowsToElement(WindowedElement<?, Integer> input) {
+    public Iterable<IntWindow> assignWindowsToElement(WindowedElement<?, Integer> input) {
       return Collections.singleton(new IntWindow(input.getElement() / 4));
     }
 
@@ -373,7 +372,7 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
     }
 
     @Override
-    public Set<CWindow> assignWindowsToElement(WindowedElement<?, T> input) {
+    public Iterable<CWindow> assignWindowsToElement(WindowedElement<?, T> input) {
       return Sets.newHashSet(new CWindow(size));
     }
 
@@ -576,7 +575,7 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
   public void testElementTimestamp() {
     class AssertingWindowing<T> implements Windowing<T, TimeInterval> {
       @Override
-      public Set<TimeInterval> assignWindowsToElement(WindowedElement<?, T> el) {
+      public Iterable<TimeInterval> assignWindowsToElement(WindowedElement<?, T> el) {
         // ~ we expect the 'element time' to be the end of the window which produced the
         // element in the preceding upstream (stateful and windowed) operator
         assertTrue(el.getTimestamp() == 15_000L - 1 || el.getTimestamp() == 25_000L - 1);

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceStateByKeyTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceStateByKeyTest.java
@@ -56,7 +56,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -612,7 +611,7 @@ public class ReduceStateByKeyTest extends AbstractOperatorTest {
 
   static class TimeAssertingWindowing<T> implements Windowing<T, TimeInterval> {
     @Override
-    public Set<TimeInterval> assignWindowsToElement(WindowedElement<?, T> input) {
+    public Iterable<TimeInterval> assignWindowsToElement(WindowedElement<?, T> input) {
       return Collections.singleton(new TimeInterval(0, Long.MAX_VALUE));
     }
 

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/AttachedWindowing.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/AttachedWindowing.java
@@ -22,7 +22,6 @@ import cz.seznam.euphoria.core.client.triggers.NoopTrigger;
 import cz.seznam.euphoria.core.client.triggers.Trigger;
 
 import java.util.Collections;
-import java.util.Set;
 
 class AttachedWindowing<T, W extends Window> implements Windowing<T, W> {
 
@@ -30,7 +29,7 @@ class AttachedWindowing<T, W extends Window> implements Windowing<T, W> {
 
   @Override
   @SuppressWarnings("unchecked")
-  public Set<W> assignWindowsToElement(WindowedElement<?, T> input) {
+  public Iterable<W> assignWindowsToElement(WindowedElement<?, T> input) {
     return Collections.singleton((W) input.getWindow());
   }
 

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/ReduceByKeyTranslator.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/ReduceByKeyTranslator.java
@@ -128,8 +128,8 @@ class ReduceByKeyTranslator implements SparkOperatorTranslator<ReduceByKey> {
         wel.setTimestamp(eventTimeAssigner.extractTimestamp(wel.getElement()));
       }
 
-      Set<Window> windows = windowing.assignWindowsToElement(wel);
-      List<Tuple2<KeyedWindow, TimestampedElement>> out = new ArrayList<>(windows.size());
+      Iterable<Window> windows = windowing.assignWindowsToElement(wel);
+      List<Tuple2<KeyedWindow, TimestampedElement>> out = new ArrayList<>();
       for (Window wid : windows) {
         Object el = wel.getElement();
         long stamp = (wid instanceof TimedWindow)

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/ReduceStateByKeyTranslator.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/ReduceStateByKeyTranslator.java
@@ -138,8 +138,8 @@ class ReduceStateByKeyTranslator implements SparkOperatorTranslator<ReduceStateB
         wel.setTimestamp(eventTimeAssigner.extractTimestamp(wel.getElement()));
       }
 
-      Set<Window> windows = windowing.assignWindowsToElement(wel);
-      List<Tuple2<KeyedWindow, Object>> out = new ArrayList<>(windows.size());
+      Iterable<Window> windows = windowing.assignWindowsToElement(wel);
+      List<Tuple2<KeyedWindow, Object>> out = new ArrayList<>();
       for (Window wid : windows) {
         Object el = wel.getElement();
         out.add(new Tuple2<>(


### PR DESCRIPTION
This PR reduces shuffle data size when using time sliding windowing by approximately 90 % according to benchmark measurement.

Instead of shuffling a collection of `TimeInterval` instances with each element, custom class `SlidingWindowSet` consisting of 3 `long` numbers  (start, end, slide interval) is used. 