### PR TITLE
Num output partitions for multi-input operators

### DIFF
--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/Datasets.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/Datasets.java
@@ -53,6 +53,52 @@ public class Datasets {
   }
 
   /**
+   * Create an output dataset for the given operator, assuming it is consuming
+   * both given inputs.
+   *
+   * @param <IN> the type of the input elements
+   * @param <OUT> the type of the operators output elements
+   *
+   * @param flow the flow the operator and the inputs are part of
+   * @param one one of the operators inputs
+   * @param two the other input of the operator
+   * @param op the operator consuming the two given inputs
+   *
+   * @return a dataset representing the output of the specified operator
+   */
+  public static <IN, OUT> Dataset<OUT> createOutputForBinaryInput(
+      Flow flow, Dataset<IN> one, Dataset<IN> two, Operator<IN, OUT> op) {
+    if (one.isBounded() != two.isBounded()) {
+      throw new IllegalStateException("Cannot combine unbounded and bounded inputs!");
+    }
+    return new OutputDataset<OUT>(flow, op, one.isBounded()) {
+      @Override
+      public int getNumPartitions() {
+        if (op instanceof PartitioningAware) {
+          return ((PartitioningAware) op).getPartitioning().getNumPartitions();
+        } else {
+          return combinedNumPartitions(one, two);
+        }
+      }
+    };
+  }
+
+  /**
+   * Determines the number of partitions when combining the two given inputs.
+   *
+   * @param x one of the input datasets
+   * @param y the other of the input datasets
+   *
+   * @return the logical number of output partitions when combining the
+   *          two given datasets
+   */
+  public static int combinedNumPartitions(Dataset<?> x, Dataset<?> y) {
+    int xn = x.getNumPartitions();
+    int yn = y.getNumPartitions();
+    return xn == -1 || yn == -1 ? -1 : (xn + yn);
+  }
+
+  /**
    * Create dataset from {@code DataSource}.
    *
    * @param <T> the type of elements in the dataset

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/InputDataset.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/InputDataset.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 
 /**
- * {@code PCollection} that is input of a {@code Flow}.
+ * {@code Dataset} representing raw input of a {@code Flow}.
  */
 abstract class InputDataset<T> implements Dataset<T> {
 
@@ -52,8 +52,7 @@ abstract class InputDataset<T> implements Dataset<T> {
 
   @Override
   public void persist(DataSink<T> sink) {
-    throw new UnsupportedOperationException(
-        "The input dataset is already stored.");
+    throw new UnsupportedOperationException("The input dataset is already stored.");
   }
 
   @Override

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Join.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Join.java
@@ -39,7 +39,10 @@ import java.util.Collection;
 import java.util.Objects;
 
 /**
- * Join two datasets by given key producing single new dataset.
+ * Join two datasets by given key producing single new dataset.<p>
+ *
+ * Unless explicitly specified, the number of output partitions will equal
+ * {@code max(left.numPartitions(), right.numPartitions()}.
  */
 @Recommended(
     reason =

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Join.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Join.java
@@ -18,6 +18,7 @@ package cz.seznam.euphoria.core.client.operator;
 import cz.seznam.euphoria.core.annotation.operator.Recommended;
 import cz.seznam.euphoria.core.annotation.operator.StateComplexity;
 import cz.seznam.euphoria.core.client.dataset.Dataset;
+import cz.seznam.euphoria.core.client.dataset.Datasets;
 import cz.seznam.euphoria.core.client.dataset.partitioning.Partitioning;
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
 import cz.seznam.euphoria.core.client.dataset.windowing.Windowing;
@@ -41,12 +42,12 @@ import java.util.Objects;
 /**
  * Join two datasets by given key producing single new dataset.<p>
  *
- * Unless explicitly specified, the number of output partitions will equal
- * {@code max(left.numPartitions(), right.numPartitions()}.
+ * Unless explicitly specified, the number of output partitions
+ * defaults to the sum of the number of partitions of both inputs.
  */
 @Recommended(
     reason =
-        "Might be useful to override because of performance reasons in a "
+        "Might be useful to override because of performance reasons for "
       + "specific join types (e.g. sort join), which might reduce the space "
       + "complexity",
     state = StateComplexity.LINEAR,
@@ -145,11 +146,13 @@ public class Join<LEFT, RIGHT, KEY, OUT, W extends Window>
       
       // define default partitioning
       super(new DefaultPartitioning<>(
-          Math.max(left.getNumPartitions(), right.getNumPartitions())));
+          Datasets.combinedNumPartitions(
+              Objects.requireNonNull(left),
+              Objects.requireNonNull(right))));
 
       this.name = Objects.requireNonNull(name);
-      this.left = Objects.requireNonNull(left);
-      this.right = Objects.requireNonNull(right);
+      this.left = left;
+      this.right = right;
       this.leftKeyExtractor = Objects.requireNonNull(leftKeyExtractor);
       this.rightKeyExtractor = Objects.requireNonNull(rightKeyExtractor);
       this.joinFunc = Objects.requireNonNull(joinFunc);

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Union.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Union.java
@@ -18,6 +18,7 @@ package cz.seznam.euphoria.core.client.operator;
 import cz.seznam.euphoria.core.annotation.operator.Basic;
 import cz.seznam.euphoria.core.annotation.operator.StateComplexity;
 import cz.seznam.euphoria.core.client.dataset.Dataset;
+import cz.seznam.euphoria.core.client.dataset.Datasets;
 import cz.seznam.euphoria.core.client.flow.Flow;
 
 import java.util.Arrays;
@@ -25,7 +26,10 @@ import java.util.Collection;
 import java.util.Objects;
 
 /**
- * Union of two datasets of same type.
+ * Union of two datasets of same type.<p>
+ *
+ * Unless explicitly specified, the number of output partitions is the sum
+ * of the number of partitions of both inputs.
  */
 @Basic(
     state = StateComplexity.ZERO,
@@ -54,6 +58,7 @@ public class Union<IN> extends Operator<IN, IN> implements OutputBuilder<IN> {
     private final String name;
     private final Dataset<IN> left;
     private final Dataset<IN> right;
+
     OutputBuilder(String name, Dataset<IN> left, Dataset<IN> right) {
       this.name = Objects.requireNonNull(name);
       this.left = Objects.requireNonNull(left);
@@ -90,7 +95,7 @@ public class Union<IN> extends Operator<IN, IN> implements OutputBuilder<IN> {
     if (left.getFlow() != right.getFlow()) {
       throw new IllegalArgumentException("Pass two datasets from the same flow.");
     }
-    this.output = createOutput(left);
+    this.output = Datasets.createOutputForBinaryInput(flow, left, right, this);
   }
 
   @Override

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/JoinTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/JoinTest.java
@@ -58,7 +58,7 @@ public class JoinTest {
 
     // default partitioning used
     assertTrue(join.getPartitioning().hasDefaultPartitioner());
-    assertEquals(3, join.getPartitioning().getNumPartitions());
+    assertEquals(5, join.getPartitioning().getNumPartitions());
   }
 
   @Test

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/UnionTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/UnionTest.java
@@ -27,10 +27,7 @@ public class UnionTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> left = Util.createMockDataset(flow, 2);
     Dataset<String> right = Util.createMockDataset(flow, 3);
-
-    Dataset<String> unioned = Union.named("Union1")
-            .of(left, right)
-            .output();
+    Dataset<String> unioned = Union.named("Union1").of(left, right).output();
 
     assertEquals(flow, unioned.getFlow());
     assertEquals(1, flow.size());
@@ -39,6 +36,8 @@ public class UnionTest {
     assertEquals(flow, union.getFlow());
     assertEquals("Union1", union.getName());
     assertEquals(unioned, union.output());
+    // ~ output partitions: sum of the input partitions
+    assertEquals(5, union.output().getNumPartitions());
   }
 
   @Test

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/UnionTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/UnionTranslator.java
@@ -17,12 +17,12 @@ package cz.seznam.euphoria.flink.batch;
 
 import cz.seznam.euphoria.core.client.operator.Union;
 import cz.seznam.euphoria.flink.FlinkOperator;
-import java.util.List;
-import java.util.Optional;
 import org.apache.flink.api.java.DataSet;
 
+import java.util.List;
+
 /**
- * Translator of {@code Union} operator.
+ * Translator for the {@link Union} operator.
  */
 class UnionTranslator implements BatchOperatorTranslator<Union> {
 
@@ -37,9 +37,6 @@ class UnionTranslator implements BatchOperatorTranslator<Union> {
       throw new IllegalStateException(
               "Should have two datasets on input, got " + inputs.size());
     }
-    Optional<DataSet> reduce = inputs.stream().reduce((l, r) -> l.union(r));
-    return reduce.get();
+    return inputs.get(0).union(inputs.get(1));
   }
-
-
 }

--- a/euphoria-inmem/src/test/java/cz/seznam/euphoria/inmem/JoinOperatorTest.java
+++ b/euphoria-inmem/src/test/java/cz/seznam/euphoria/inmem/JoinOperatorTest.java
@@ -92,6 +92,7 @@ public class JoinOperatorTest {
         .using((l, r, c) ->
             c.collect((l == null ? 0 : l.getSecond()) + (r == null ? 0 : r.getSecond())))
         .applyIf(outer, b -> b.outer())
+        .setNumPartitions(1)
         .windowBy(windowing)
         .output();
 

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/JoinTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/JoinTest.java
@@ -70,6 +70,7 @@ public class JoinTest extends AbstractOperatorTest {
             .by(e -> e, e -> (int) (e % 10))
             .using((Integer l, Long r, Context<String> c) -> c.collect(l + "+" + r))
             .setPartitioner(e -> e % 2)
+            .setNumPartitions(2)
             .outer()
             .output();
       }
@@ -122,6 +123,7 @@ public class JoinTest extends AbstractOperatorTest {
             .by(e -> e, e -> (int) (e % 10))
             .using((Integer l, Long r, Context<String> c) -> c.collect(l + "+" + r))
             .setPartitioner(e -> e % 2)
+            .setNumPartitions(2)
             .output();
       }
 

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/JoinWindowEnforcementTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/JoinWindowEnforcementTest.java
@@ -135,7 +135,8 @@ public class JoinWindowEnforcementTest extends AbstractOperatorTest {
             Join.of(left, right)
                 .by(e -> e, e -> e)
                 .using((l, r, c) -> c.collect(new Object()))
-                .setPartitioner(e -> 0);
+                .setPartitioner(e -> 0)
+                .setNumPartitions(1);
         if (joinWindowing == null) {
           return joinBuilder.output();
         } else {


### PR DESCRIPTION
* Sets `#getNumPartitions() == sum(input.getNumPartitions()` for the two multi input operators we have, i.e. `Union` and `Join`
* An explicit test in the operator-testkit seems no necessary due to the change being guaranteed by `euphoria-core` already
* Resolves #92 
