### PR TITLE
Document Repartition and ReduceStateByKey

### DIFF
--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Distinct.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Distinct.java
@@ -159,9 +159,8 @@ public class Distinct<IN, ELEM, W extends Window>
   public DAG<Operator<?, ?>> getBasicOps() {
     Flow flow = input.getFlow();
     String name = getName() + "::" + "ReduceByKey";
-    ReduceByKey<IN, IN, ELEM, Void, IN, Void, W>
-        reduce;
-    reduce = new ReduceByKey<>(name,
+    ReduceByKey<IN, ELEM, Void, Void, W> reduce =
+        new ReduceByKey<>(name,
             flow, input, getKeyExtractor(), e -> null,
             windowing, eventTimeAssigner,
             (CombinableReduceFunction<Void>) e -> null, partitioning);

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Join.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Join.java
@@ -437,13 +437,9 @@ public class Join<LEFT, RIGHT, KEY, OUT, W extends Window>
     Union<Either<LEFT, RIGHT>> union =
         new Union<>(name, flow, leftMap.output(), rightMap.output());
 
-    ReduceStateByKey<Either<LEFT, RIGHT>, Either<LEFT, RIGHT>, Either<LEFT, RIGHT>,
-        KEY, Either<LEFT, RIGHT>, KEY,
-        OUT, JoinState, W> reduce;
-
-    name = getName() + "::ReduceStateByKey";
-    reduce = new ReduceStateByKey(
-              name,
+    ReduceStateByKey<Either<LEFT, RIGHT>, KEY, Either<LEFT, RIGHT>, OUT, JoinState, W>
+        reduce = new ReduceStateByKey(
+              getName() + "::ReduceStateByKey",
               flow,
               union.output(),
               keyExtractor,

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceByKey.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceByKey.java
@@ -44,10 +44,8 @@ import java.util.Objects;
  * Operator performing state-less aggregation by given reduce function.
  *
  * @param <IN> Type of input records
- * @param <KIN> Type of records entering #keyBy and #valueBy methods
  * @param <KEY> Output type of #keyBy method
  * @param <VALUE> Output type of #valueBy method
- * @param <KEYOUT> Type of output key
  * @param <OUT> Type of output value
  */
 @Recommended(
@@ -59,10 +57,10 @@ import java.util.Objects;
     repartitions = 1
 )
 public class ReduceByKey<
-    IN, KIN, KEY, VALUE, KEYOUT, OUT, W extends Window>
+    IN, KEY, VALUE, OUT, W extends Window>
     extends StateAwareWindowWiseSingleInputOperator<
-        IN, IN, KIN, KEY, Pair<KEYOUT, OUT>, W,
-        ReduceByKey<IN, KIN, KEY, VALUE, KEYOUT, OUT, W>> {
+        IN, IN, IN, KEY, Pair<KEY, OUT>, W,
+        ReduceByKey<IN, KEY, VALUE, OUT, W>> {
 
   public static class OfBuilder {
     private final String name;
@@ -216,7 +214,7 @@ public class ReduceByKey<
     @Override
     public Dataset<Pair<KEY, OUT>> output() {
       Flow flow = input.getFlow();
-      ReduceByKey<IN, IN, KEY, VALUE, KEY, OUT, W>
+      ReduceByKey<IN, KEY, VALUE, OUT, W>
           reduce =
           new ReduceByKey<>(name, flow, input, keyExtractor, valueExtractor,
               windowing, eventTimeAssigner, reducer, getPartitioning());
@@ -234,13 +232,13 @@ public class ReduceByKey<
   }
 
   final ReduceFunction<VALUE, OUT> reducer;
-  final UnaryFunction<KIN, VALUE> valueExtractor;
+  final UnaryFunction<IN, VALUE> valueExtractor;
 
   ReduceByKey(String name,
               Flow flow,
               Dataset<IN> input,
-              UnaryFunction<KIN, KEY> keyExtractor,
-              UnaryFunction<KIN, VALUE> valueExtractor,
+              UnaryFunction<IN, KEY> keyExtractor,
+              UnaryFunction<IN, VALUE> valueExtractor,
               @Nullable Windowing<IN, W> windowing,
               @Nullable ExtractEventTime<IN> eventTimeAssigner,
               ReduceFunction<VALUE, OUT> reducer,
@@ -254,7 +252,7 @@ public class ReduceByKey<
     return reducer;
   }
 
-  public UnaryFunction<KIN, VALUE> getValueExtractor() {
+  public UnaryFunction<IN, VALUE> getValueExtractor() {
     return valueExtractor;
   }
 

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceStateByKey.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceStateByKey.java
@@ -32,26 +32,60 @@ import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
- * Operator reducing state by given reduce function.
+ * A {@link ReduceStateByKey} operator is a stateful, complex, lower-level-api,
+ * but very powerful processor and serves as the basis for easier-to-use
+ * operators. Client API users have generally little motivation to use it
+ * directly and should prefer {@link ReduceByKey} when possible.<p>
  *
- * @param <IN>     Type of input records
- * @param <KIN>    Type of records entering #keyBy and #valueBy methods
- * @param <WIN>    Type of input records being windowed
- * @param <KEY>    Output type of #keyBy method
- * @param <VALUE>  Output type of #valueBy method
- * @param <KEYOUT> Type of output key
- * @param <OUT>    Type of output value
+ * The operator assigns each input item to a set of windows (through a user
+ * provided {@link Windowing} implementation) and turns the item into a
+ * key/value pair. For each of the assigned windows the extracted value is
+ * accumulated using a user provided {@link StateFactory state implementation}
+ * under the extracted key. I.e. the value is accumulated into a state
+ * identified by a key/window pair.<p>
+ *
+ * Example:
+ *
+ * <pre>{@code
+ *  Dataset<String> words = ...;
+ *  Dataset<Pair<String, Integer>> counts =
+ *      ReduceStateByKey.named("WORD-COUNT")
+ *          .of(words)
+ *          .keyBy(s -> s)
+ *          .valueBy(s -> 1)
+ *          .stateFactory(WordCountState::new)
+ *          .mergeStatesBy(WordCountState::merge)
+ *          .windowBy(Time.of(Duration.ofHours(1))
+ *          .output();
+ * }</pre>
+ *
+ * This example constitutes a windowed word-count program. Each input element
+ * is treated as a key to identify an imaginary {@code WordCountState} within
+ * each time window assigned to the input element. For such a key/window
+ * combination the value {@code 1} gets sent to the corresponding state.<p>
+ *
+ * States are emitted based on the used {@link Windowing} strategy. See that
+ * for more information. Generally speaking, when a window is emitted/triggered,
+ * the states of all keys within the emitted window are flushed.
+ *
+ * Note that defining a {@link Windowing} strategy is actually optional. If
+ * none is defined the operator will act in the so-call "attached windowing"
+ * mode, i.e. it will attach itself to the windowing strategy active on they
+ * way from its input.
+ *
+ * @param <IN>     the type of input elements
+ * @param <KEY>    the type of the key (result type of {@code #keyBy}
+ * @param <VALUE>  the type of the accumulated values (result type of {@code #valueBy})
+ * @param <OUT>    the type of the output elements (result type of the accumulated state)
  */
 @Basic(
     state = StateComplexity.CONSTANT_IF_COMBINABLE,
     repartitions = 1
 )
 public class ReduceStateByKey<
-    IN, KIN, WIN, KEY, VALUE, KEYOUT, OUT, STATE extends State<VALUE, OUT>,
-    W extends Window>
-    extends StateAwareWindowWiseSingleInputOperator<IN, WIN, KIN, KEY,
-        Pair<KEYOUT, OUT>, W,
-        ReduceStateByKey<IN, KIN, WIN, KEY, VALUE, KEYOUT, OUT, STATE, W>>
+    IN, KEY, VALUE, OUT, STATE extends State<VALUE, OUT>, W extends Window>
+    extends StateAwareWindowWiseSingleInputOperator<
+        IN, IN, IN, KEY, Pair<KEY, OUT>, W, ReduceStateByKey<IN, KEY, VALUE, OUT, STATE, W>>
 {
 
   public static class OfBuilder {
@@ -61,6 +95,16 @@ public class ReduceStateByKey<
       this.name = name;
     }
 
+    /**
+     * Specifies the input dataset to reduce.
+     *
+     * @param <IN> the type of elements in the input dataset
+     *
+     * @param input the input dataset to recuce
+     *
+     * @return the next builder to complete the setup of the
+     *          {@link ReduceStateByKey} operator
+     */
     public <IN> DatasetBuilder1<IN> of(Dataset<IN> input) {
       return new DatasetBuilder1<>(name, input);
     }
@@ -71,10 +115,24 @@ public class ReduceStateByKey<
   public static class DatasetBuilder1<IN> {
     private final String name;
     private final Dataset<IN> input;
+
     DatasetBuilder1(String name, Dataset<IN> input) {
       this.name = Objects.requireNonNull(name);
       this.input = Objects.requireNonNull(input);
     }
+
+    /**
+     * Specifies the function to derive the keys from the
+     * {@link ReduceStateByKey operator's} input elements.
+     *
+     * @param <KEY> the type of the extracted key
+     *
+     * @param keyExtractor a user defined function to extract keys from the
+     *                      processed input dataset's elements
+     *
+     * @return the next builder to complete the setup of the
+     *          {@link ReduceStateByKey} operator
+     */
     public <KEY> DatasetBuilder2<IN, KEY> keyBy(UnaryFunction<IN, KEY> keyExtractor) {
       return new DatasetBuilder2<>(name, input, keyExtractor);
     }
@@ -91,6 +149,20 @@ public class ReduceStateByKey<
       this.keyExtractor = Objects.requireNonNull(keyExtractor);
     }
 
+    /**
+     * Specifies the function to derive a value from the
+     * {@link ReduceStateByKey operator's} input elements to get later
+     * accumulated by a later supplied state implementation.
+     *
+     * @param <VALUE> the type of the extracted values
+     *
+     * @param valueExtractor a user defined function to extract values from the
+     *                        processed input dataset's elements for later
+     *                        accumulation
+     *
+     * @return the next builder to complete the setup of the
+     *          {@link ReduceStateByKey} operator
+     */
     public <VALUE> DatasetBuilder3<IN, KEY, VALUE> valueBy(UnaryFunction<IN, VALUE> valueExtractor) {
       return new DatasetBuilder3<>(name, input, keyExtractor, valueExtractor);
     }
@@ -113,6 +185,20 @@ public class ReduceStateByKey<
       this.valueExtractor = Objects.requireNonNull(valueExtractor);
     }
 
+    /**
+     * Specifies a factory for creating new/empty/blank state instances.
+     *
+     * @param <OUT> the type of output elements state instances will produce;
+     *               along with the "key", this is part of the type of output
+     *               elements the {@link ReduceStateByKey} operator will produce
+     *               as such
+     * @param <STATE> the type of the state (implementation)
+     *
+     * @param stateFactory a user supplied function to create new state instances
+     *
+     * @return the next builder to complete the setup of the
+     *          {@link ReduceStateByKey} operator
+     */
     public <OUT, STATE extends State<VALUE, OUT>> DatasetBuilder4<
             IN, KEY, VALUE, OUT, STATE> stateFactory(
             StateFactory<VALUE, OUT, STATE> stateFactory) {
@@ -142,6 +228,16 @@ public class ReduceStateByKey<
       this.stateFactory = Objects.requireNonNull(stateFactory);
     }
 
+    /**
+     * Specifies the merging function to be utilized when states get merged
+     * as part of {@link cz.seznam.euphoria.core.client.dataset.windowing.MergingWindowing window merging}.
+     *
+     * @param stateMerger a user defined function to merge mutilple states into
+     *                   a specified target state
+     *
+     * @return the next builder to complete the setup of the
+     *          {@link ReduceStateByKey} operator
+     */
     public DatasetBuilder5<IN, KEY, VALUE, OUT, STATE>
     mergeStatesBy(StateMerger<VALUE, OUT, STATE> stateMerger) {
       return new DatasetBuilder5<>(name, input, keyExtractor, valueExtractor,
@@ -178,21 +274,56 @@ public class ReduceStateByKey<
       this.stateMerger = Objects.requireNonNull(stateMerger);
     }
 
-    public <WIN, W extends Window>
-    DatasetBuilder6<IN, WIN, KEY, VALUE, OUT, STATE, W>
-    windowBy(Windowing<WIN, W> windowing)
+    /**
+     * Specifies the windowing strategy to be applied to the
+     * {@link ReduceStateByKey operator's} input dataset without specifying
+     * an {@link ExtractEventTime event time assigner.} Unless the operator
+     * is already preceded by an event time assignment, it will process in
+     * the input elements in ingestion time.
+     *
+     * @param <W> the type of the windowing
+     *
+     * @param windowing the windowing strategy to apply to the input dataset
+     *
+     * @return the next builder to complete the setup of the
+     *          {@link ReduceStateByKey} operator
+     *
+     * @see #windowBy(Windowing, ExtractEventTime)
+     */
+    public <W extends Window>
+    DatasetBuilder6<IN, KEY, VALUE, OUT, STATE, W>
+    windowBy(Windowing<IN, W> windowing)
     {
       return windowBy(windowing, null);
     }
 
-    public <WIN, W extends Window>
-    DatasetBuilder6<IN, WIN, KEY, VALUE, OUT, STATE, W>
-    windowBy(Windowing<WIN, W> windowing, ExtractEventTime<WIN> eventTimeAssigner) {
+    /**
+     * Specifies the windowing strategy to be applied to the
+     * {@link ReduceStateByKey operator's} input dataset specifying
+     * an {@link ExtractEventTime event time assigner} to (re-)assign
+     * the element's logical timestamp.
+     *
+     * @param <W> the type of the windowing
+     *
+     * @param windowing the windowing strategy to apply to the input dataset
+     *
+     * @return the next builder to complete the setup of the
+     *          {@link ReduceStateByKey} operator
+     */
+    public <W extends Window>
+    DatasetBuilder6<IN, KEY, VALUE, OUT, STATE, W>
+    windowBy(Windowing<IN, W> windowing, ExtractEventTime<IN> eventTimeAssigner) {
       return new DatasetBuilder6<>(name, input, keyExtractor, valueExtractor,
               stateFactory, stateMerger,
               Objects.requireNonNull(windowing), eventTimeAssigner, this);
     }
 
+    /**
+     * Finalizes the built {@link ReduceStateByKey} operator and retrieves
+     * its output dataset.
+     *
+     * @return the dataset representing the new operator's output
+     */
     @Override
     public Dataset<Pair<KEY, OUT>> output() {
       return new DatasetBuilder6<>(name, input, keyExtractor, valueExtractor,
@@ -202,10 +333,10 @@ public class ReduceStateByKey<
   }
 
   public static class DatasetBuilder6<
-          IN, WIN, KEY, VALUE, OUT, STATE extends State<VALUE, OUT>,
+          IN, KEY, VALUE, OUT, STATE extends State<VALUE, OUT>,
           W extends Window>
       extends PartitioningBuilder<
-          KEY,DatasetBuilder6<IN, WIN, KEY, VALUE, OUT, STATE, W>>
+          KEY,DatasetBuilder6<IN, KEY, VALUE, OUT, STATE, W>>
       implements OutputBuilder<Pair<KEY, OUT>> {
 
     private final String name;
@@ -215,9 +346,9 @@ public class ReduceStateByKey<
     private final StateFactory<VALUE, OUT, STATE> stateFactory;
     private final StateMerger<VALUE, OUT, STATE> stateMerger;
     @Nullable
-    private final Windowing<WIN, W> windowing;
+    private final Windowing<IN, W> windowing;
     @Nullable
-    private final ExtractEventTime<WIN> eventTimeAssigner;
+    private final ExtractEventTime<IN> eventTimeAssigner;
 
     DatasetBuilder6(String name,
                     Dataset<IN> input,
@@ -225,8 +356,8 @@ public class ReduceStateByKey<
                     UnaryFunction<IN, VALUE> valueExtractor,
                     StateFactory<VALUE, OUT, STATE> stateFactory,
                     StateMerger<VALUE, OUT, STATE> stateMerger,
-                    @Nullable Windowing<WIN, W> windowing,
-                    @Nullable ExtractEventTime<WIN> eventTimeAssigner,
+                    @Nullable Windowing<IN, W> windowing,
+                    @Nullable ExtractEventTime<IN> eventTimeAssigner,
                     PartitioningBuilder<KEY, ?> partitioning)
     {
       // initialize partitioning
@@ -242,11 +373,17 @@ public class ReduceStateByKey<
       this.eventTimeAssigner = eventTimeAssigner;
     }
 
+    /**
+     * Finalizes the built {@link ReduceStateByKey} operator and retrieves
+     * its output dataset.
+     *
+     * @return the dataset representing the new operator's output
+     */
     @Override
     public Dataset<Pair<KEY, OUT>> output() {
       Flow flow = input.getFlow();
 
-      ReduceStateByKey<IN, IN, WIN, KEY, VALUE, KEY, OUT, STATE, W>
+      ReduceStateByKey<IN, KEY, VALUE, OUT, STATE, W>
           reduceStateByKey =
           new ReduceStateByKey<>(name, flow, input, keyExtractor, valueExtractor,
               windowing, eventTimeAssigner, stateFactory, stateMerger, getPartitioning());
@@ -256,27 +393,45 @@ public class ReduceStateByKey<
     }
   }
 
-  // -------------
-
+  /**
+   * Starts building a nameless {@link ReduceStateByKey} operator to process
+   * the given input dataset.
+   *
+   * @param <IN> the type of elements of the input dataset
+   *
+   * @param input the input data set to be processed
+   *
+   * @return a builder to complete the setup of the new operator
+   *
+   * @see #named(String)
+   * @see OfBuilder#of(Dataset)
+   */
   public static <IN> DatasetBuilder1<IN> of(Dataset<IN> input) {
     return new DatasetBuilder1<>("ReduceStateByKey", input);
   }
 
+  /**
+   * Starts building a named {@link ReduceStateByKey} operator.
+   *
+   * @param name a user provided name of the new operator to build
+   *
+   * @return a builder to complete the setup of the new operator
+   */
   public static OfBuilder named(String name) {
     return new OfBuilder(name);
   }
 
   private final StateFactory<VALUE, OUT, STATE> stateFactory;
-  private final UnaryFunction<KIN, VALUE> valueExtractor;
+  private final UnaryFunction<IN, VALUE> valueExtractor;
   private final StateMerger<VALUE, OUT, STATE> stateCombiner;
 
   ReduceStateByKey(String name,
                    Flow flow,
                    Dataset<IN> input,
-                   UnaryFunction<KIN, KEY> keyExtractor,
-                   UnaryFunction<KIN, VALUE> valueExtractor,
-                   @Nullable Windowing<WIN, W> windowing,
-                   @Nullable ExtractEventTime<WIN> eventTimeAssigner,
+                   UnaryFunction<IN, KEY> keyExtractor,
+                   UnaryFunction<IN, VALUE> valueExtractor,
+                   @Nullable Windowing<IN, W> windowing,
+                   @Nullable ExtractEventTime<IN> eventTimeAssigner,
                    StateFactory<VALUE, OUT, STATE> stateFactory,
                    StateMerger<VALUE, OUT, STATE> stateMerger,
                    Partitioning<KEY> partitioning)
@@ -287,15 +442,30 @@ public class ReduceStateByKey<
     this.stateCombiner = stateMerger;
   }
 
+  /**
+   * Retrieves the user defined state factory function.
+   *
+   * @return the user provided state factory
+   */
   public StateFactory<VALUE, OUT, STATE> getStateFactory() {
     return stateFactory;
   }
 
-  public UnaryFunction<KIN, VALUE> getValueExtractor() {
-    return valueExtractor;
-  }
-
+  /**
+   * Retrieves the user defined state merger function.
+   *
+   * @return the user provided state merger
+   */
   public StateMerger<VALUE, OUT, STATE> getStateMerger() {
     return stateCombiner;
+  }
+
+  /**
+   * Retrieves the user defined key extractor function.
+   *
+   * @return the user provided key extractor function
+   */
+  public UnaryFunction<IN, VALUE> getValueExtractor() {
+    return valueExtractor;
   }
 }

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceWindow.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceWindow.java
@@ -191,14 +191,14 @@ public class ReduceWindow<
   @Override
   public DAG<Operator<?, ?>> getBasicOps() {
     // implement this operator via `ReduceByKey`
-    ReduceByKey<IN, IN, Byte, VALUE, Void, OUT, W> reduceByKey;
+    ReduceByKey<IN, Byte, VALUE, OUT, W> reduceByKey;
     reduceByKey = new ReduceByKey<>(
         getName() + "::ReduceByKey", getFlow(), input,
         getKeyExtractor(), valueExtractor,
         windowing, eventTimeAssigner, reducer, partitioning);
-    Dataset<Pair<Void, OUT>> output = reduceByKey.output();
+    Dataset<Pair<Byte, OUT>> output = reduceByKey.output();
 
-    MapElements<Pair<Void, OUT>, OUT> format = new MapElements<>(
+    MapElements<Pair<Byte, OUT>, OUT> format = new MapElements<>(
         getName() + "::MapElements", getFlow(), output, Pair::getSecond);
 
     return DAG.of(reduceByKey, format);

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Sort.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Sort.java
@@ -288,7 +288,7 @@ public class Sort<IN, S extends Comparable<? super S>, W extends Window>
     final StateSupport.MergeFromStateMerger<IN, IN, Sorted<IN>> stateCombiner = 
         new StateSupport.MergeFromStateMerger<>();
     final SortByComparator<IN, S> comparator = new SortByComparator<>(sortByFn);
-    ReduceStateByKey<IN, IN, IN, Integer, IN, Integer, IN, Sorted<IN>, W> reduce = 
+    ReduceStateByKey<IN, Integer, IN, IN, Sorted<IN>, W> reduce =
         new ReduceStateByKey<>(getName() + "::ReduceStateByKey", flow, input,
                 keyExtractor,
                 e -> e,

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/SumByKey.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/SumByKey.java
@@ -37,11 +37,9 @@ import java.util.Objects;
     state = StateComplexity.CONSTANT,
     repartitions = 1
 )
-public class SumByKey<
-    IN, KEY, W extends Window>
+public class SumByKey<IN, KEY, W extends Window>
     extends StateAwareWindowWiseSingleInputOperator<
-        IN, IN, IN, KEY, Pair<KEY, Long>, W,
-        SumByKey<IN, KEY, W>> {
+        IN, IN, IN, KEY, Pair<KEY, Long>, W, SumByKey<IN, KEY, W>> {
   
   public static class OfBuilder {
     private final String name;
@@ -167,7 +165,7 @@ public class SumByKey<
 
   @Override
   public DAG<Operator<?, ?>> getBasicOps() {
-    ReduceByKey<IN, IN, KEY, Long, KEY, Long, W> reduceByKey =
+    ReduceByKey<IN, KEY, Long, Long, W> reduceByKey =
         new ReduceByKey<>(getName(), input.getFlow(), input,
         keyExtractor, valueExtractor, windowing, eventTimeAssigner,
                 Sums.ofLongs(), getPartitioning());

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/TopPerKey.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/TopPerKey.java
@@ -291,7 +291,7 @@ public class TopPerKey<
 
     StateSupport.MergeFromStateMerger<Pair<VALUE, SCORE>, Pair<VALUE, SCORE>, MaxScored<VALUE, SCORE>>
             stateCombiner = new StateSupport.MergeFromStateMerger<>();
-    ReduceStateByKey<IN, IN, IN, KEY, Pair<VALUE, SCORE>, KEY, Pair<VALUE, SCORE>,
+    ReduceStateByKey<IN, KEY, Pair<VALUE, SCORE>, Pair<VALUE, SCORE>,
         MaxScored<VALUE, SCORE>, W>
         reduce =
         new ReduceStateByKey<>(getName() + "::ReduceStateByKey", flow, input,

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceStateByKeyTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceStateByKeyTest.java
@@ -15,7 +15,6 @@
  */
 package cz.seznam.euphoria.operator.test;
 
-import cz.seznam.euphoria.shaded.guava.com.google.common.collect.Lists;
 import cz.seznam.euphoria.core.client.dataset.Dataset;
 import cz.seznam.euphoria.core.client.dataset.windowing.Count;
 import cz.seznam.euphoria.core.client.dataset.windowing.Session;
@@ -27,7 +26,6 @@ import cz.seznam.euphoria.core.client.dataset.windowing.WindowedElement;
 import cz.seznam.euphoria.core.client.dataset.windowing.Windowing;
 import cz.seznam.euphoria.core.client.functional.UnaryFunctor;
 import cz.seznam.euphoria.core.client.io.Context;
-import cz.seznam.euphoria.core.client.operator.ExtractEventTime;
 import cz.seznam.euphoria.core.client.operator.FlatMap;
 import cz.seznam.euphoria.core.client.operator.ReduceStateByKey;
 import cz.seznam.euphoria.core.client.operator.state.ListStorage;
@@ -44,6 +42,7 @@ import cz.seznam.euphoria.core.client.util.Pair;
 import cz.seznam.euphoria.core.client.util.Triple;
 import cz.seznam.euphoria.operator.test.junit.AbstractOperatorTest;
 import cz.seznam.euphoria.operator.test.junit.Processing;
+import cz.seznam.euphoria.shaded.guava.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -641,8 +640,7 @@ public class ReduceStateByKeyTest extends AbstractOperatorTest {
                 .valueBy(Pair::getFirst)
                 .stateFactory(ReduceByKeyTest.SumState::new)
                 .mergeStatesBy(ReduceByKeyTest.SumState::combine)
-                .windowBy(Time.of(Duration.ofSeconds(5)),
-                          (ExtractEventTime<Pair<String, Integer>>) Pair::getSecond)
+                .windowBy(Time.of(Duration.ofSeconds(5)), Pair::getSecond)
                 .output();
         // ~ now use a custom windowing with a trigger which does
         // the assertions subject to this test (use RSBK which has to


### PR DESCRIPTION
* Javadocs
* Some cleanup regarding generic type parameters on the `ReduceStateByKey` operator