### PR TITLE
#13 [euphoria-flink] Batch executor uses hash code as a key in shufflles

### DIFF
--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceByKeyTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceByKeyTranslator.java
@@ -149,12 +149,11 @@ public class ReduceByKeyTranslator implements BatchOperatorTranslator<ReduceByKe
   static class RBKKeySelector
           implements KeySelector<BatchElement<Window, Pair>, Integer> {
 
-    private final Tuple2 tuple = new Tuple2();
-    
     @Override
     public Integer getKey(
             BatchElement<Window, Pair> value) {
 
+      Tuple2 tuple = new Tuple2();
       tuple.f0 = value.getWindow();
       tuple.f1 =  value.getElement().getFirst();
       return tuple.hashCode();

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceByKeyTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceByKeyTranslator.java
@@ -113,8 +113,6 @@ public class ReduceByKeyTranslator implements BatchOperatorTranslator<ReduceByKe
     // ~ reduce the data now
     Operator<BatchElement<Window, Pair>, ?> reduced =
             tuples.groupBy(new RBKKeySelector())
-                    .combineGroup(new RBKReducer(reducer))
-                    .groupBy(new RBKKeySelector())
                     .reduceGroup(new RBKReducer(reducer))
                     .setParallelism(operator.getParallelism())
                     .name(operator.getName() + "::reduce");
@@ -190,13 +188,11 @@ public class ReduceByKeyTranslator implements BatchOperatorTranslator<ReduceByKe
       // Tuple2[Window, Key] => Reduced Value
       Map<Tuple2, BatchElement<Window, Pair>> reducedValues = new HashMap<>();
 
-      Tuple2 kw = new Tuple2();
       for (BatchElement<Window, Pair> batchElement : values) {
         Object key = batchElement.getElement().getFirst();
         Window window = batchElement.getWindow();
 
-        kw.f0 = window;
-        kw.f1 = key;
+        Tuple2 kw = new Tuple2<>(window, key);
         BatchElement<Window, Pair> val = reducedValues.get(kw);
         if (val == null) {
           reducedValues.put(kw, batchElement);

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceByKeyTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceByKeyTranslator.java
@@ -28,15 +28,21 @@ import cz.seznam.euphoria.flink.Utils;
 import cz.seznam.euphoria.flink.functions.PartitionerWrapper;
 import cz.seznam.euphoria.shaded.guava.com.google.common.base.Preconditions;
 import cz.seznam.euphoria.shaded.guava.com.google.common.collect.Iterables;
-import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.GroupCombineFunction;
+import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.operators.FlatMapOperator;
 import org.apache.flink.api.java.operators.Operator;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.util.Collector;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ReduceByKeyTranslator implements BatchOperatorTranslator<ReduceByKey> {
 
@@ -80,8 +86,6 @@ public class ReduceByKeyTranslator implements BatchOperatorTranslator<ReduceByKe
     // ~ extract key/value from input elements and assign windows
     DataSet<BatchElement<Window, Pair>> tuples;
     {
-      // FIXME require keyExtractor to deliver `Comparable`s
-
       ExtractEventTime timeAssigner = origOperator.getEventTimeAssigner();
       FlatMapOperator<Object, BatchElement<Window, Pair>> wAssigned =
           input.flatMap((i, c) -> {
@@ -109,7 +113,9 @@ public class ReduceByKeyTranslator implements BatchOperatorTranslator<ReduceByKe
     // ~ reduce the data now
     Operator<BatchElement<Window, Pair>, ?> reduced =
             tuples.groupBy(new RBKKeySelector())
-                    .reduce(new RBKReducer(reducer))
+                    .combineGroup(new RBKReducer(reducer))
+                    .groupBy(new RBKKeySelector())
+                    .reduceGroup(new RBKReducer(reducer))
                     .setParallelism(operator.getParallelism())
                     .name(operator.getName() + "::reduce");
 
@@ -135,22 +141,32 @@ public class ReduceByKeyTranslator implements BatchOperatorTranslator<ReduceByKe
   // ------------------------------------------------------------------------------
 
   /**
-   * Produces Tuple2[Window, Element Key]
+   * Grouping by key hashcode will effectively group elements with the same key
+   * to the one bucket. Although there may occur some collisions that we need
+   * to be aware of in later processing.
+   * <p>
+   * Produces Tuple2[Window, Element Key].hashCode
    */
   @SuppressWarnings("unchecked")
   static class RBKKeySelector
-          implements KeySelector<BatchElement<Window, Pair>, Tuple2<Comparable, Comparable>> {
+          implements KeySelector<BatchElement<Window, Pair>, Integer> {
+
+    private final Tuple2 tuple = new Tuple2();
     
     @Override
-    public Tuple2<Comparable, Comparable> getKey(
+    public Integer getKey(
             BatchElement<Window, Pair> value) {
 
-      return new Tuple2(value.getWindow(), value.getElement().getFirst());
+      tuple.f0 = value.getWindow();
+      tuple.f1 =  value.getElement().getFirst();
+      return tuple.hashCode();
     }
   }
 
   static class RBKReducer
-        implements ReduceFunction<BatchElement<Window, Pair>> {
+          implements GroupReduceFunction<BatchElement<Window, Pair>, BatchElement<Window, Pair>>,
+          GroupCombineFunction<BatchElement<Window, Pair>, BatchElement<Window, Pair>>,
+          ResultTypeQueryable<BatchElement<Window, Pair>> {
 
     final UnaryFunction<Iterable, Object> reducer;
 
@@ -159,16 +175,52 @@ public class ReduceByKeyTranslator implements BatchOperatorTranslator<ReduceByKe
     }
 
     @Override
-    public BatchElement<Window, Pair>
-    reduce(BatchElement<Window, Pair> p1, BatchElement<Window, Pair> p2) {
+    public void combine(Iterable<BatchElement<Window, Pair>> values, Collector<BatchElement<Window, Pair>> out) {
+      doReduce(values, out);
+    }
 
-      Window wid = p1.getWindow();
-      return new BatchElement<>(
-              wid,
-              Math.max(p1.getTimestamp(), p2.getTimestamp()),
-              Pair.of(
-                      p1.getElement().getFirst(),
-                      reducer.apply(Arrays.asList(p1.getElement().getSecond(), p2.getElement().getSecond()))));
+    @Override
+    public void reduce(Iterable<BatchElement<Window, Pair>> values, Collector<BatchElement<Window, Pair>> out) {
+      doReduce(values, out);
+    }
+
+    private void doReduce(Iterable<BatchElement<Window, Pair>> values,
+                       org.apache.flink.util.Collector<BatchElement<Window, Pair>> out) {
+
+      // Tuple2[Window, Key] => Reduced Value
+      Map<Tuple2, BatchElement<Window, Pair>> reducedValues = new HashMap<>();
+
+      Tuple2 kw = new Tuple2();
+      for (BatchElement<Window, Pair> batchElement : values) {
+        Object key = batchElement.getElement().getFirst();
+        Window window = batchElement.getWindow();
+
+        kw.f0 = window;
+        kw.f1 = key;
+        BatchElement<Window, Pair> val = reducedValues.get(kw);
+        if (val == null) {
+          reducedValues.put(kw, batchElement);
+        } else {
+          Object reduced =
+                  reducer.apply(Arrays.asList(val.getElement().getSecond(),
+                          batchElement.getElement().getSecond()));
+
+          reducedValues.put(kw, new BatchElement<>(
+                  window,
+                  Math.max(val.getTimestamp(), batchElement.getTimestamp()),
+                  Pair.of(key, reduced)));
+        }
+      }
+
+      for (Map.Entry<Tuple2, BatchElement<Window, Pair>> e : reducedValues.entrySet()) {
+        out.collect(e.getValue());
+      }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public TypeInformation<BatchElement<Window, Pair>> getProducedType() {
+      return TypeInformation.of((Class) BatchElement.class);
     }
   }
 }

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceStateByKeyTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceStateByKeyTranslator.java
@@ -161,7 +161,7 @@ public class ReduceStateByKeyTranslator implements BatchOperatorTranslator<Reduc
     {
       activeReducers = new HashMap<>();
       for (BatchElement<?, Pair> batchElement : values) {
-        Object key = batchElement.getElement().getKey();
+        Object key = batchElement.getElement().getFirst();
 
         GroupReducer reducer = activeReducers.get(key);
         if (reducer == null) {

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/TimestampedElement.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/TimestampedElement.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016-2017 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.flink.batch;
+
+final class TimestampedElement {
+
+  private long timestamp;
+  private Object el;
+
+  public TimestampedElement(long timestamp, Object el) {
+    this.timestamp = timestamp;
+    this.el = el;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public Object getElement() {
+    return el;
+  }
+
+  public void setElement(Object el) {
+    this.el = el;
+  }
+}


### PR DESCRIPTION
I have finally finished this improvement. Comparing elements in shuffle by hashcode (integer) is much faster than deserializing and calling `.compareTo` on original instance.

The result is batch executor's performance is a about 3 times better compared to previous version.