### PR TITLE
Early emitting state

### DIFF
--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Session.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/windowing/Session.java
@@ -15,6 +15,7 @@
  */
 package cz.seznam.euphoria.core.client.dataset.windowing;
 
+import cz.seznam.euphoria.core.annotation.stability.Experimental;
 import cz.seznam.euphoria.core.client.triggers.AfterFirstCompositeTrigger;
 import cz.seznam.euphoria.core.client.triggers.PeriodicTimeTrigger;
 import cz.seznam.euphoria.core.client.triggers.TimeTrigger;
@@ -59,6 +60,7 @@ public final class Session<T> implements MergingWindowing<T, TimeInterval> {
    *
    * @return this instance (for method chaining purposes)
    */
+  @Experimental("https://github.com/seznam/euphoria/issues/43")
   @SuppressWarnings("unchecked")
   public <T> Session<T> earlyTriggering(Duration timeout) {
     this.earlyTriggeringPeriod = Objects.requireNonNull(timeout);

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Join.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Join.java
@@ -390,8 +390,9 @@ public class Join<LEFT, RIGHT, KEY, OUT, W extends Window>
 
   /**
    * An implementation of the join state which produces results, i.e. emits
-   * output, as soon as possible. It has at least the following short commings
-   * and should be used with care:
+   * output, as soon as possible. It has at least the following short comings
+   * and should be used with care (see https://github.com/seznam/euphoria/issues/118
+   * for more information):
    *
    * <ul>
    *   <li>This implementation will break the join operator if used with a
@@ -405,6 +406,7 @@ public class Join<LEFT, RIGHT, KEY, OUT, W extends Window>
    *        thus, marking earlier - but actually still not too late time-sliding
    *        windows as late comers.</li>
    * </ul>
+   *
    *
    */
   @Experimental

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Join.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Join.java
@@ -400,6 +400,10 @@ public class Join<LEFT, RIGHT, KEY, OUT, W extends Window>
    *   <li>This implementation cannot be used together with early triggering
    *        on any windowing strategy as it will emit each identified pair
    *        only once during the whole course of the state's life cycle.</li>
+   *   <li>This implementation will also break time-sliding windowing, as
+   *        it will raise the watermark too quickly in downstream operators,
+   *        thus, marking earlier - but actually still not too late time-sliding
+   *        windows as late comers.</li>
    * </ul>
    *
    */

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/state/State.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/state/State.java
@@ -17,44 +17,31 @@ package cz.seznam.euphoria.core.client.operator.state;
 
 import cz.seznam.euphoria.core.client.io.Context;
 
-import java.io.Closeable;
-
 /**
  * A state for stateful operations.
  */
-public abstract class State<IN, OUT> implements Closeable {
-
-  /** Collector of output of this state. */
-  private final Context<OUT> context;
+public interface State<IN, OUT> {
 
   /**
    * Add element to this state.
    *
    * @param element the element to add/accumulate to this state
    */
-  public abstract void add(IN element);
+  void add(IN element);
 
   /**
    * Flush the state to output. Invoked when window this
    * state is part of gets disposed/triggered.
+   *
+   * @param context the context to utilize for emitting output elements;
+   *                 never {@code null}
    */
-  public abstract void flush();
-
-  protected State(Context<OUT> context) {
-    
-    this.context = context;
-  }
-
-  public Context<OUT> getContext() {
-    return context;
-  }
+  void flush(Context<OUT> context);
 
   /**
-   * Closes this state. Invoked after {@link #flush()} and before
-   * this state gets disposed.
+   * Closes this state. Invoked after {@link #flush(Context)} and before
+   * this state gets disposed to allow clean-up of temporary state storage.
    */
-  public void close() {
-    // ~ no-op by default
-  }
+  void close();
 
 }

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/state/StateFactory.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/state/StateFactory.java
@@ -15,8 +15,10 @@
  */
 package cz.seznam.euphoria.core.client.operator.state;
 
+import cz.seznam.euphoria.core.annotation.stability.Experimental;
 import cz.seznam.euphoria.core.client.io.Context;
 
+import javax.annotation.Nullable;
 import java.io.Serializable;
 
 /**
@@ -25,6 +27,17 @@ import java.io.Serializable;
 @FunctionalInterface
 public interface StateFactory<IN, OUT, STATE extends State<IN, OUT>> extends Serializable {
 
-  STATE createState(Context<OUT> context, StorageProvider storageProvider);
+  /**
+   * Factory method to create new state instances.
+   *
+   * @param storageProvider the provider for physical storage accessors
+   * @param context a context allowing the newly created state for the
+   *                duration of its existence to emit output elements
+   *
+   * @return a newly created state
+   */
+  STATE createState(StorageProvider storageProvider,
+                    @Experimental("may break merging windowing and downstream watermarking")
+                    @Nullable Context<OUT> context);
 
 }

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/state/StateFactory.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/state/StateFactory.java
@@ -37,7 +37,7 @@ public interface StateFactory<IN, OUT, STATE extends State<IN, OUT>> extends Ser
    * @return a newly created state
    */
   STATE createState(StorageProvider storageProvider,
-                    @Experimental("may break merging windowing and downstream watermarking")
+                    @Experimental("https://github.com/seznam/euphoria/issues/118")
                     @Nullable Context<OUT> context);
 
 }

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/ReduceStateByKeyTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/ReduceStateByKeyTest.java
@@ -148,16 +148,12 @@ public class ReduceStateByKeyTest {
   /**
    * Simple aggregating state.
    */
-  private static class WordCountState extends State<Long, Long> {
-
+  private static class WordCountState implements State<Long, Long> {
     private final ValueStorage<Long> sum;
 
-    protected WordCountState(
-        Context<Long> context,
-        StorageProvider storageProvider) {
-      super(context);
-      sum = storageProvider.getValueStorage(ValueStorageDescriptor.of(
-          "sum", Long.class, 0L));
+    protected WordCountState(StorageProvider storageProvider, Context<Long> ctx) {
+      sum = storageProvider.getValueStorage(
+          ValueStorageDescriptor.of("sum", Long.class, 0L));
     }
 
     @Override
@@ -166,8 +162,8 @@ public class ReduceStateByKeyTest {
     }
 
     @Override
-    public void flush() {
-      this.getContext().collect(sum.get());
+    public void flush(Context<Long> ctx) {
+      ctx.collect(sum.get());
     }
 
     static void combine(WordCountState target, Iterable<WordCountState> others) {

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/BatchStateStorageProvider.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/BatchStateStorageProvider.java
@@ -25,13 +25,13 @@ import cz.seznam.euphoria.core.client.operator.state.StorageProvider;
 import cz.seznam.euphoria.core.client.operator.state.ValueStorage;
 import cz.seznam.euphoria.core.client.operator.state.ValueStorageDescriptor;
 import cz.seznam.euphoria.shaded.guava.com.google.common.io.Closeables;
-import org.apache.commons.io.IOUtils;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -153,7 +153,7 @@ class BatchStateStorageProvider implements StorageProvider, Serializable {
           input = null;
         } else {
           finput = new FileInputStream(serializedElements);
-          input = new Input(IOUtils.toBufferedInputStream(finput));
+          input = new Input(new BufferedInputStream(finput));
         }
       } catch (Exception ex) {
         throw new RuntimeException(ex);

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceStateByKeyTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/ReduceStateByKeyTranslator.java
@@ -172,8 +172,8 @@ public class ReduceStateByKeyTranslator implements BatchOperatorTranslator<Reduc
                   BatchElement::new,
                   windowing,
                   trigger,
-                  elem -> out.collect((BatchElement) elem));
-
+                  elem -> out.collect((BatchElement) elem),
+                  false);
           activeReducers.put(key, reducer);
         }
 

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/KeyedMultiWindowedElementWindowOperator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/KeyedMultiWindowedElementWindowOperator.java
@@ -34,8 +34,10 @@ public class KeyedMultiWindowedElementWindowOperator<KEY, WID extends Window>
             StateFactory<?, ?, State<?, ?>> stateFactory,
             StateMerger<?, ?, State<?, ?>> stateCombiner,
             boolean localMode,
-            int descriptorsCacheMaxSize) {
-        super(windowing, stateFactory, stateCombiner, localMode, descriptorsCacheMaxSize);
+            int descriptorsCacheMaxSize,
+            boolean allowEarlyEmitting) {
+        super(windowing, stateFactory, stateCombiner, localMode,
+            descriptorsCacheMaxSize, allowEarlyEmitting);
     }
 
     @Override

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/StreamingElementWindowOperator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/streaming/windowing/StreamingElementWindowOperator.java
@@ -17,9 +17,8 @@ package cz.seznam.euphoria.flink.streaming.windowing;
 
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
 import cz.seznam.euphoria.core.client.dataset.windowing.Windowing;
-import cz.seznam.euphoria.core.client.functional.CombinableReduceFunction;
-import cz.seznam.euphoria.core.client.operator.state.StateFactory;
 import cz.seznam.euphoria.core.client.operator.state.State;
+import cz.seznam.euphoria.core.client.operator.state.StateFactory;
 import cz.seznam.euphoria.core.client.operator.state.StateMerger;
 import cz.seznam.euphoria.flink.streaming.StreamingElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -42,8 +41,10 @@ public class StreamingElementWindowOperator<KEY, WID extends Window>
           StateFactory<?, ?, State<?, ?>> stateFactory,
           StateMerger<?, ?, State<?, ?>> stateCombiner,
           boolean localMode,
-          int descriptorsCacheMaxSize) {
-    super(windowing, stateFactory, stateCombiner, localMode, descriptorsCacheMaxSize);
+          int descriptorsCacheMaxSize,
+          boolean allowEarlyEmitting) {
+    super(windowing, stateFactory, stateCombiner, localMode,
+        descriptorsCacheMaxSize, allowEarlyEmitting);
     this.windowAssigner = Objects.requireNonNull(windowAssigner);
   }
 

--- a/euphoria-flink/src/test/java/cz/seznam/euphoria/flink/testkit/FlinkExecutorProvider.java
+++ b/euphoria-flink/src/test/java/cz/seznam/euphoria/flink/testkit/FlinkExecutorProvider.java
@@ -30,7 +30,8 @@ public interface FlinkExecutorProvider extends ExecutorProvider {
   default ExecutorEnvironment newExecutorEnvironment() throws Exception {
     String path = "/tmp/.flink-test-" + System.currentTimeMillis();
     RocksDBStateBackend backend = new RocksDBStateBackend("file://" + path);
-    FlinkExecutor executor = new TestFlinkExecutor(ModuloInputSplitAssigner::new).setStateBackend(backend);
+    FlinkExecutor executor = new TestFlinkExecutor(ModuloInputSplitAssigner::new)
+        .setStateBackend(backend);
     return new ExecutorEnvironment() {
       @Override
       public Executor getExecutor() {

--- a/euphoria-inmem/src/main/java/cz/seznam/euphoria/inmem/InMemExecutor.java
+++ b/euphoria-inmem/src/main/java/cz/seznam/euphoria/inmem/InMemExecutor.java
@@ -248,8 +248,25 @@ public class InMemExecutor implements Executor {
       = ProcessingTimeTriggerScheduler::new;
 
   private boolean allowWindowBasedShuffling = false;
+  private boolean allowEarlyEmitting = false;
 
   private StorageProvider storageProvider = new InMemStorageProvider();
+
+  /**
+   * Specifies whether stateful operators are allowed to emit their results
+   * early.<p>
+   *
+   * Defaults to {@code false}.
+   *
+   * @param allowEarlyEmitting {@code true} to allow states to emit early
+   *                           results, {@code false} otherwise
+   *
+   * @return this instance (for method chaining purposes)
+   */
+  public InMemExecutor setAllowEarlyEmitting(boolean allowEarlyEmitting) {
+    this.allowEarlyEmitting = allowEarlyEmitting;
+    return this;
+  }
 
   /**
    * Set supplier for watermark emit strategy used in state operations.
@@ -632,7 +649,8 @@ public class InMemExecutor implements Executor {
                   ? triggerSchedulerSupplier.get()
                   : new WatermarkTriggerScheduler(watermarkDuration)),
           watermarkEmitStrategySupplier.get(),
-          storageProvider));
+          storageProvider,
+          allowEarlyEmitting));
     }
     return outputSuppliers;
   }

--- a/euphoria-inmem/src/test/java/cz/seznam/euphoria/inmem/InMemExecutorTest.java
+++ b/euphoria-inmem/src/test/java/cz/seznam/euphoria/inmem/InMemExecutorTest.java
@@ -268,15 +268,11 @@ public class InMemExecutorTest {
    * Simple sort state for tests.
    * This state takes comparable elements and produces sorted sequence.
    */
-  public static class SortState extends State<Integer, Integer> {
+  public static class SortState implements State<Integer, Integer> {
 
     final ListStorage<Integer> data;
 
-    SortState(
-        Context<Integer> c,
-        StorageProvider storageProvider) {
-      
-      super(c);
+    SortState(StorageProvider storageProvider, Context<Integer> c) {
       data = storageProvider.getListStorage(
           ListStorageDescriptor.of("data", Integer.class));
     }
@@ -288,11 +284,11 @@ public class InMemExecutorTest {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void flush() {
+    public void flush(Context<Integer> context) {
       List<Integer> toSort = Lists.newArrayList(data.get());
       Collections.sort(toSort);
       for (Integer i : toSort) {
-        getContext().collect(i);
+        context.collect(i);
       }
     }
 

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/JoinTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/JoinTest.java
@@ -125,7 +125,9 @@ public class JoinTest extends AbstractOperatorTest {
           Dataset<Integer> left, Dataset<Long> right) {
         return Join.of(left, right)
             .by(e -> e, e -> (int) (e % 10))
-            .using((Integer l, Long r, Context<String> c) -> c.collect(l + "+" + r))
+            .using((Integer l, Long r, Context<String> c) -> {
+                c.collect(l + "+" + r);
+            })
             .setPartitioner(e -> e % 2)
             .output();
       }

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceByKeyTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceByKeyTest.java
@@ -61,7 +61,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test operator {@code ReduceByKey}.
@@ -531,11 +533,10 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
 
   // ~ ------------------------------------------------------------------------------
 
-  static class SumState extends State<Integer, Integer> {
+  static class SumState implements State<Integer, Integer> {
     private final ValueStorage<Integer> sum;
 
-    SumState(Context<Integer> context, StorageProvider storageProvider) {
-      super(context);
+    SumState(StorageProvider storageProvider, Context<Integer> context) {
       sum = storageProvider.getValueStorage(
           ValueStorageDescriptor.of("sum-state", Integer.class, 0));
     }
@@ -546,8 +547,8 @@ public class ReduceByKeyTest extends AbstractOperatorTest {
     }
 
     @Override
-    public void flush() {
-      getContext().collect(sum.get());
+    public void flush(Context<Integer> context) {
+      context.collect(sum.get());
     }
 
     @Override

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceStateByKeyTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/ReduceStateByKeyTest.java
@@ -65,12 +65,11 @@ import static org.junit.Assert.assertTrue;
 @Processing(Processing.Type.ALL)
 public class ReduceStateByKeyTest extends AbstractOperatorTest {
 
-  static class SortState extends State<Integer, Integer> {
+  static class SortState implements State<Integer, Integer> {
 
     final ListStorage<Integer> data;
 
-    SortState(Context<Integer> c, StorageProvider storageProvider) {
-      super(c);
+    SortState(StorageProvider storageProvider, Context<Integer> c) {
       this.data = storageProvider.getListStorage(
           ListStorageDescriptor.of("data", Integer.class));
     }
@@ -81,11 +80,11 @@ public class ReduceStateByKeyTest extends AbstractOperatorTest {
     }
 
     @Override
-    public void flush() {
+    public void flush(Context<Integer> context) {
       List<Integer> list = Lists.newArrayList(data.get());
       Collections.sort(list);
       for (Integer i : list) {
-        this.getContext().collect(i);
+        context.collect(i);
       }
     }
 
@@ -221,11 +220,9 @@ public class ReduceStateByKeyTest extends AbstractOperatorTest {
 
   // ---------------------------------------------------------------------------------
 
-  private static class CountState<IN> extends State<IN, Long> {
+  private static class CountState<IN> implements State<IN, Long> {
     final ValueStorage<Long> count;
-    CountState(Context<Long> context, StorageProvider storageProvider)
-    {
-      super(context);
+    CountState(StorageProvider storageProvider, Context<Long> context) {
       this.count = storageProvider.getValueStorage(
           ValueStorageDescriptor.of("count-state", Long.class, 0L));
     }
@@ -237,8 +234,8 @@ public class ReduceStateByKeyTest extends AbstractOperatorTest {
     }
 
     @Override
-    public void flush() {
-      getContext().collect(count.get());
+    public void flush(Context<Long> context) {
+      context.collect(count.get());
     }
 
     void add(CountState<IN> other) {
@@ -318,13 +315,10 @@ public class ReduceStateByKeyTest extends AbstractOperatorTest {
 
   // ---------------------------------------------------------------------------------
 
-  private static class AccState<VALUE> extends State<VALUE, VALUE> {
+  private static class AccState<VALUE> implements State<VALUE, VALUE> {
     final ListStorage<VALUE> vals;
     @SuppressWarnings("unchecked")
-    AccState(Context<VALUE> context,
-             StorageProvider storageProvider)
-    {
-      super(context);
+    AccState(StorageProvider storageProvider, Context<VALUE> context) {
       vals = storageProvider.getListStorage(
           ListStorageDescriptor.of("vals", (Class) Object.class));
     }
@@ -335,9 +329,9 @@ public class ReduceStateByKeyTest extends AbstractOperatorTest {
     }
 
     @Override
-    public void flush() {
+    public void flush(Context<VALUE> context) {
       for (VALUE value : vals.get()) {
-        getContext().collect(value);
+        context.collect(value);
       }
     }
 

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/WindowingTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/WindowingTest.java
@@ -213,12 +213,11 @@ public class WindowingTest extends AbstractOperatorTest {
     });
   }
 
-  private static class DistinctState extends State<Object, Object> {
+  private static class DistinctState implements State<Object, Object> {
 
     private final ValueStorage<Object> storage;
 
-    public DistinctState(Context<Object> context, StorageProvider storageProvider) {
-      super(context);
+    DistinctState(StorageProvider storageProvider, Context<Object> context) {
       this.storage = storageProvider.getValueStorage(
               ValueStorageDescriptor.of("element", Object.class, null));
     }
@@ -229,8 +228,13 @@ public class WindowingTest extends AbstractOperatorTest {
     }
 
     @Override
-    public void flush() {
-      getContext().collect(storage.get());
+    public void flush(Context<Object> context) {
+      context.collect(storage.get());
+    }
+
+    @Override
+    public void close() {
+      storage.clear();
     }
   }
 

--- a/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/junit/AbstractOperatorTest.java
+++ b/euphoria-operator-testkit/src/main/java/cz/seznam/euphoria/operator/test/junit/AbstractOperatorTest.java
@@ -77,6 +77,9 @@ public abstract class AbstractOperatorTest implements Serializable {
 
     /** @return the number of runs for the test */
     default int getNumRuns() { return 1; }
+
+    /** Retrieve test specific settings to be applied to the test flow. */
+    default Settings getSettings() { return new Settings(); }
   }
 
   /**
@@ -205,7 +208,7 @@ public abstract class AbstractOperatorTest implements Serializable {
     for (Processing.Type proc: processing.asList()) {
       for (int i = 0; i < tc.getNumRuns(); i++) {
         ListDataSink<?> sink = ListDataSink.get(tc.getNumOutputPartitions());
-        Flow flow = Flow.create(tc.toString());
+        Flow flow = Flow.create(tc.toString(), tc.getSettings());
         Dataset output = tc.getOutput(flow, proc == Type.BOUNDED);
         // skip if output is not supported for the processing type
         output.persist(sink);

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/ReduceStateByKeyTranslator.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/ReduceStateByKeyTranslator.java
@@ -201,7 +201,8 @@ class ReduceStateByKeyTranslator implements SparkOperatorTranslator<ReduceStateB
                     SparkElement::new,
                     windowing,
                     trigger,
-                    el -> context.collect((SparkElement) el));
+                    el -> context.collect((SparkElement) el),
+                    false);
 
             activeReducers.put(kw.key(), reducer);
           }


### PR DESCRIPTION
* Fixes the Join operator to produce stable output, i.e. without early emitting
* Provides an experimental early emitting implementation of the JoinState, similar to the previously existing implementation
* Support early emitting on the inmem and flink streaming executors through an executor parameter
* Resolves #105