### PR TITLE
#133 Accumulator API integrated to all executors

### DIFF
--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/io/Environment.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/io/Environment.java
@@ -36,18 +36,13 @@ public interface Environment {
 
   // ---------------- Aggregator related methods ------------
 
-  // FIXME remove default implementation
-  // it's just temporary to make the whole project compilable
-
   /**
    * Get an existing instance of a counter or create a new one.
    *
    * @param name Unique name of the counter.
    * @return Instance of a counter.
    */
-  default Counter getCounter(String name) {
-    throw new IllegalStateException("Accumulators not supported yet.");
-  }
+  Counter getCounter(String name);
 
   /**
    * Get an existing instance of a histogram or create a new one.
@@ -55,9 +50,7 @@ public interface Environment {
    * @param name Unique name of the histogram.
    * @return Instance of a histogram.
    */
-  default Histogram getHistogram(String name) {
-    throw new IllegalStateException("Accumulators not supported yet.");
-  }
+  Histogram getHistogram(String name);
 
   /**
    * Get an existing instance of a timer or create a new one.
@@ -65,7 +58,5 @@ public interface Environment {
    * @param name Unique name of the timer.
    * @return Instance of a timer.
    */
-  default Timer getTimer(String name) {
-    throw new IllegalStateException("Accumulators not supported yet.");
-  }
+  Timer getTimer(String name);
 }

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/EventTimeAssigningUnaryFunctor.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/EventTimeAssigningUnaryFunctor.java
@@ -15,9 +15,11 @@
  */
 package cz.seznam.euphoria.spark;
 
+import cz.seznam.euphoria.core.client.accumulators.AccumulatorProvider;
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
 import cz.seznam.euphoria.core.client.functional.UnaryFunctor;
 import cz.seznam.euphoria.core.client.operator.ExtractEventTime;
+import cz.seznam.euphoria.core.util.Settings;
 
 import java.util.Objects;
 
@@ -27,8 +29,10 @@ class EventTimeAssigningUnaryFunctor<WID extends Window, IN, OUT>
   private final ExtractEventTime<IN> evtTimeFn;
 
   EventTimeAssigningUnaryFunctor(UnaryFunctor<IN, OUT> functor,
-                                 ExtractEventTime<IN> evtTimeFn) {
-    super(functor);
+                                 ExtractEventTime<IN> evtTimeFn,
+                                 AccumulatorProvider.Factory accumulatorFactory,
+                                 Settings settings) {
+    super(functor, accumulatorFactory, settings);
     this.evtTimeFn = Objects.requireNonNull(evtTimeFn);
   }
 

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/FlatMapTranslator.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/FlatMapTranslator.java
@@ -33,9 +33,12 @@ class FlatMapTranslator implements SparkOperatorTranslator<FlatMap> {
     final ExtractEventTime<?> evtTimeFn = operator.getEventTimeExtractor();
 
     if (evtTimeFn != null) {
-      return input.flatMap(new EventTimeAssigningUnaryFunctor(mapper, evtTimeFn));
+      return input.flatMap(
+              new EventTimeAssigningUnaryFunctor(mapper, evtTimeFn,
+                      context.getAccumulatorFactory(), context.getSettings()));
     } else {
-      return input.flatMap(new UnaryFunctorWrapper(mapper));
+      return input.flatMap(new UnaryFunctorWrapper(mapper,
+              context.getAccumulatorFactory(), context.getSettings()));
     }
   }
 }

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/FunctionCollector.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/FunctionCollector.java
@@ -15,27 +15,68 @@
  */
 package cz.seznam.euphoria.spark;
 
+import cz.seznam.euphoria.core.client.accumulators.AccumulatorProvider;
+import cz.seznam.euphoria.core.client.accumulators.Counter;
+import cz.seznam.euphoria.core.client.accumulators.Histogram;
+import cz.seznam.euphoria.core.client.accumulators.Timer;
 import cz.seznam.euphoria.core.client.io.Collector;
 import cz.seznam.euphoria.core.client.io.Context;
+import cz.seznam.euphoria.core.util.Settings;
+
+import java.util.Objects;
 
 abstract class FunctionCollector<T> implements Context, Collector<T> {
 
-  protected KeyedWindow window;
+  private final AccumulatorProvider.Factory accumulatorFactory;
+  private final Settings settings;
+
+  private AccumulatorProvider accumulators;
+  private Object window;
+
+  public FunctionCollector(AccumulatorProvider.Factory accumulatorFactory,
+                           Settings settings) {
+    this.accumulatorFactory = Objects.requireNonNull(accumulatorFactory);
+    this.settings = Objects.requireNonNull(settings);
+  }
 
   @Override
   public abstract void collect(T elem);
 
   @Override
   public Object getWindow() {
-    return this.window.window();
+    return this.window;
   }
 
-  public void setWindow(KeyedWindow window) {
+  public void setWindow(Object window) {
     this.window = window;
   }
 
   @Override
   public Context asContext() {
     return this;
+  }
+
+  @Override
+  public Counter getCounter(String name) {
+    return getAccumulatorProvider().getCounter(name);
+  }
+
+  @Override
+  public Histogram getHistogram(String name) {
+    return getAccumulatorProvider().getHistogram(name);
+  }
+
+  @Override
+  public Timer getTimer(String name) {
+    return getAccumulatorProvider().getTimer(name);
+  }
+
+
+  private AccumulatorProvider getAccumulatorProvider() {
+    if (accumulators == null) {
+      accumulators = accumulatorFactory.create(settings);
+    }
+
+    return accumulators;
   }
 }

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/FunctionCollectorAsync.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/FunctionCollectorAsync.java
@@ -15,7 +15,9 @@
  */
 package cz.seznam.euphoria.spark;
 
+import cz.seznam.euphoria.core.client.accumulators.AccumulatorProvider;
 import cz.seznam.euphoria.core.client.io.Collector;
+import cz.seznam.euphoria.core.util.Settings;
 import cz.seznam.euphoria.shaded.guava.com.google.common.collect.AbstractIterator;
 import cz.seznam.euphoria.shaded.guava.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -39,6 +41,11 @@ class FunctionCollectorAsync<T> extends FunctionCollector<T> {
 
   /** Used as an end-of-message token in the queue */
   private final static Object EOM = new Object();
+
+  public FunctionCollectorAsync(AccumulatorProvider.Factory accumulatorFactory,
+                                Settings settings) {
+    super(accumulatorFactory, settings);
+  }
 
   /**
    * Blocks until the item is consumed by runtime.

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/FunctionCollectorMem.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/FunctionCollectorMem.java
@@ -15,10 +15,11 @@
  */
 package cz.seznam.euphoria.spark;
 
+import cz.seznam.euphoria.core.client.accumulators.AccumulatorProvider;
 import cz.seznam.euphoria.core.client.io.Collector;
 import cz.seznam.euphoria.core.client.io.Context;
+import cz.seznam.euphoria.core.util.Settings;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -27,10 +28,14 @@ import java.util.List;
  * Implementation of {@link Collector} that holds all the
  * data in memory.
  */
-class FunctionCollectorMem<T> implements Context, Collector<T>, Serializable {
+class FunctionCollectorMem<T> extends FunctionCollector<T> {
 
   private final List<T> elements = new ArrayList<>(1);
-  private Object window;
+
+  public FunctionCollectorMem(AccumulatorProvider.Factory accumulatorFactory,
+                              Settings settings) {
+    super(accumulatorFactory, settings);
+  }
 
   @Override
   public void collect(T elem) {
@@ -40,15 +45,6 @@ class FunctionCollectorMem<T> implements Context, Collector<T>, Serializable {
   @Override
   public Context asContext() {
     return this;
-  }
-
-  @Override
-  public Object getWindow() {
-    return this.window;
-  }
-
-  public void setWindow(Object window) {
-    this.window = window;
   }
 
   /**

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/SparkExecutorContext.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/SparkExecutorContext.java
@@ -15,9 +15,11 @@
  */
 package cz.seznam.euphoria.spark;
 
+import cz.seznam.euphoria.core.client.accumulators.AccumulatorProvider;
 import cz.seznam.euphoria.core.client.graph.DAG;
 import cz.seznam.euphoria.core.client.graph.Node;
 import cz.seznam.euphoria.core.client.operator.Operator;
+import cz.seznam.euphoria.core.util.Settings;
 import cz.seznam.euphoria.shaded.guava.com.google.common.collect.Iterables;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -37,9 +39,18 @@ public class SparkExecutorContext {
   private final DAG<Operator<?, ?>> dag;
   private final Map<Operator<?, ?>, JavaRDD<?>> outputs;
 
-  public SparkExecutorContext(JavaSparkContext env, DAG<Operator<?, ?>> dag) {
+  private final AccumulatorProvider.Factory accumulatorFactory;
+  private final Settings settings;
+
+
+  public SparkExecutorContext(JavaSparkContext env,
+                              DAG<Operator<?, ?>> dag,
+                              AccumulatorProvider.Factory accumulatorFactory,
+                              Settings settings) {
     this.env = env;
     this.dag = dag;
+    this.accumulatorFactory = accumulatorFactory;
+    this.settings = settings;
     this.outputs = new IdentityHashMap<>();
   }
 
@@ -108,5 +119,13 @@ public class SparkExecutorContext {
       throw new IllegalStateException(
               "Operator(" + operator.getName() + ") output already processed");
     }
+  }
+
+  public AccumulatorProvider.Factory getAccumulatorFactory() {
+    return accumulatorFactory;
+  }
+
+  public Settings getSettings() {
+    return settings;
   }
 }

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/UnaryFunctorWrapper.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/UnaryFunctorWrapper.java
@@ -32,7 +32,7 @@ class UnaryFunctorWrapper<WID extends Window, IN, OUT>
   private final AccumulatorProvider.Factory accumulatorFactory;
   private final Settings settings;
 
-  private FunctionCollectorMem<OUT> cachedCollector;
+  private transient FunctionCollectorMem<OUT> cachedCollector;
 
   public UnaryFunctorWrapper(UnaryFunctor<IN, OUT> functor,
                              AccumulatorProvider.Factory accumulatorFactory,


### PR DESCRIPTION
I removed the `FIXME` from the `Environment` class and implemented the accumulator support to all collectors in both remaining executors (Spark, in-mem).

closes #133 