### PR TITLE
 [euphoria-core] remove checkpointing from datasets - unusable feature

### DIFF
--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/Dataset.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/Dataset.java
@@ -77,13 +77,6 @@ public interface Dataset<T> extends Serializable {
   void persist(DataSink<T> sink);
 
   /**
-   * Checkpoint this dataset.
-   *
-   * @param sink the sink to use to checkpoint this data set's data to
-   */
-  void checkpoint(DataSink<T> sink);
-
-  /**
    * Retrieve output sink for this dataset.
    *
    * @return {@code null} if there is no explicitly set sink this
@@ -95,14 +88,4 @@ public interface Dataset<T> extends Serializable {
     return null;
   }
 
-  /**
-   * Retrieve checkpoint sink for this dataset.
-   *
-   * @return {@code null} if no checkpoint sink has been defined,
-   *          otherwise the sink provided through {@link #checkpoint(DataSink)}
-   */
-  @Nullable
-  default DataSink<T> getCheckpointSink() {
-    return null;
-  }
 }

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/InputDataset.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/InputDataset.java
@@ -59,11 +59,6 @@ class InputDataset<T> implements Dataset<T> {
   }
 
   @Override
-  public void checkpoint(DataSink<T> sink) {
-    throw new UnsupportedOperationException("Do not checkpoint inputs.");
-  }
-
-  @Override
   public Flow getFlow() {
     return flow;
   }

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/OutputDataset.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/dataset/OutputDataset.java
@@ -35,7 +35,6 @@ class OutputDataset<T> implements Dataset<T> {
   private final boolean bounded;
 
   private DataSink<T> outputSink = null;
-  private DataSink<T> checkpointSink = null;
 
   public OutputDataset(Flow flow, Operator<?, T> producer, boolean bounded) {
     this.flow = flow;
@@ -60,21 +59,10 @@ class OutputDataset<T> implements Dataset<T> {
     outputSink = sink;
   }
 
-  @Override
-  public void checkpoint(DataSink<T> sink) {
-    checkpointSink = sink;
-  }
-
   @Nullable
   @Override
   public DataSink<T> getOutputSink() {
     return outputSink;
-  }
-
-  @Nullable
-  @Override
-  public DataSink<T> getCheckpointSink() {
-    return checkpointSink;
   }
 
   @Override

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/executor/FlowUnfolder.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/executor/FlowUnfolder.java
@@ -171,11 +171,9 @@ public class FlowUnfolder {
         // we have to link the original output dataset with given replaced operator
         datasetProducents.put(n.get().output(), Optional.of(leaf));
 
-        // and propagate output and checkpoint sinks
+        // and propagate output sinks
         if (n.get().output().getOutputSink() != null) {
           leaf.output().persist((DataSink) n.get().output().getOutputSink());
-        } else if (n.get().output().getCheckpointSink() != null) {
-          leaf.output().checkpoint((DataSink) n.get().output().getCheckpointSink());
         }
       }
 


### PR DESCRIPTION
This was absolutely unimplemented feature, possibly just confusing clients, and most of all, batch specific.