### PR TITLE
[euphoria-core] make sure that windowBy() can be appliedIf()

### DIFF
--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Builders.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Builders.java
@@ -63,7 +63,13 @@ public class Builders {
     <KEY> Object keyBy(UnaryFunction<IN, KEY> keyExtractor);
   }
 
-  interface WindowBy<IN> {
+  /**
+   * Interface for builders of windowing.
+   * @param <IN> data type of the input elements
+   * @param <BUILDER> the builder
+   */
+  interface WindowBy<IN, BUILDER extends WindowBy<IN, BUILDER>>
+      extends OptionalMethodBuilder<BUILDER> {
 
     /**
      * Specifies the windowing strategy to be applied to the input dataset.
@@ -77,7 +83,8 @@ public class Builders {
      * @return the next builder to complete the setup of the
      *          {@link ReduceByKey} operator
      */
-    <W extends Window> Object windowBy(Windowing<IN, W> windowing);
+    <W extends Window> BUILDER windowBy(Windowing<IN, W> windowing);
+
   }
 
   public interface Output<T> {

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/CountByKey.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/CountByKey.java
@@ -70,10 +70,12 @@ public class CountByKey<IN, KEY, W extends Window>
   }
 
   public static class WindowingBuilder<IN, KEY>
-          implements Builders.WindowBy<IN>, Builders.Output<Pair<KEY, Long>> {
-    private final String name;
-    private final Dataset<IN> input;
-    private final UnaryFunction<IN, KEY> keyExtractor;
+      implements Builders.WindowBy<IN, WindowingBuilder<IN, KEY>>,
+      Builders.Output<Pair<KEY, Long>> {
+
+    final String name;
+    final Dataset<IN> input;
+    final UnaryFunction<IN, KEY> keyExtractor;
 
     WindowingBuilder(String name, Dataset<IN> input, UnaryFunction<IN, KEY> keyExtractor) {
       this.name = Objects.requireNonNull(name);
@@ -94,11 +96,9 @@ public class CountByKey<IN, KEY, W extends Window>
   }
 
   public static class OutputBuilder<IN, KEY, W extends Window>
-          implements Builders.Output<Pair<KEY, Long>> {
+      extends WindowingBuilder<IN, KEY>
+      implements Builders.Output<Pair<KEY, Long>> {
 
-    private final String name;
-    private final Dataset<IN> input;
-    private final UnaryFunction<IN, KEY> keyExtractor;
     @Nullable
     private final Windowing<IN, W> windowing;
 
@@ -107,9 +107,7 @@ public class CountByKey<IN, KEY, W extends Window>
                   UnaryFunction<IN, KEY> keyExtractor,
                   @Nullable Windowing<IN, W> windowing) {
 
-      this.name = Objects.requireNonNull(name);
-      this.input = Objects.requireNonNull(input);
-      this.keyExtractor = Objects.requireNonNull(keyExtractor);
+      super(name, input, keyExtractor);
       this.windowing = windowing;
     }
 

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Distinct.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Distinct.java
@@ -44,8 +44,7 @@ import java.util.Objects;
 )
 public class Distinct<IN, ELEM, W extends Window>
     extends StateAwareWindowWiseSingleInputOperator<
-        IN, IN, IN, ELEM, ELEM, W, Distinct<IN, ELEM, W>>
-{
+        IN, IN, IN, ELEM, ELEM, W, Distinct<IN, ELEM, W>> {
 
   public static class OfBuilder implements Builders.Of {
     private final String name;
@@ -61,14 +60,14 @@ public class Distinct<IN, ELEM, W extends Window>
   }
 
   public static class WindowingBuilder<IN, ELEM>
-          implements Builders.WindowBy<IN>,
-                     Builders.Output<ELEM>,
-                     OptionalMethodBuilder<WindowingBuilder<IN, ELEM>>
-  {
-    private final String name;
-    private final Dataset<IN> input;
+      implements Builders.WindowBy<IN, WindowingBuilder<IN, ELEM>>,
+      Builders.Output<ELEM>,
+      OptionalMethodBuilder<WindowingBuilder<IN, ELEM>> {
+
+    final String name;
+    final Dataset<IN> input;
     @Nullable
-    private final UnaryFunction<IN, ELEM> mapper;
+    final UnaryFunction<IN, ELEM> mapper;
 
     WindowingBuilder(
         String name,
@@ -112,12 +111,9 @@ public class Distinct<IN, ELEM, W extends Window>
   }
 
   public static class OutputBuilder<IN, ELEM, W extends Window>
-      implements Builders.Output<ELEM>
-  {
-    private final String name;
-    private final Dataset<IN> input;
-    @Nullable
-    private final UnaryFunction<IN, ELEM> mapper;
+      extends WindowingBuilder<IN, ELEM>
+      implements Builders.Output<ELEM> {
+
     @Nullable
     private final Windowing<IN, W> windowing;
 
@@ -126,9 +122,7 @@ public class Distinct<IN, ELEM, W extends Window>
                   @Nullable UnaryFunction<IN, ELEM> mapper,
                   @Nullable Windowing<IN, W> windowing) {
 
-      this.name = Objects.requireNonNull(name);
-      this.input = Objects.requireNonNull(input);
-      this.mapper = mapper;
+      super(name, input, mapper);
       this.windowing = windowing;
     }
 

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceByKey.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceByKey.java
@@ -225,8 +225,9 @@ public class ReduceByKey<IN, KEY, VALUE, OUT, W extends Window>
   }
 
   public static class DatasetBuilder4<IN, KEY, VALUE, OUT>
-          implements Builders.OutputValues<KEY, OUT>, Builders.WindowBy<IN>,
-              OptionalMethodBuilder<DatasetBuilder4<IN, KEY, VALUE, OUT>> {
+      implements Builders.Output<Pair<KEY, OUT>>,
+          Builders.OutputValues<KEY, OUT>,
+          Builders.WindowBy<IN, DatasetBuilder4<IN, KEY, VALUE, OUT>> {
 
     final String name;
     final Dataset<IN> input;
@@ -272,12 +273,13 @@ public class ReduceByKey<IN, KEY, VALUE, OUT, W extends Window>
   public static class SortableDatasetBuilder4<IN, KEY, VALUE, OUT>
       extends DatasetBuilder4<IN, KEY, VALUE, OUT> {
 
-    SortableDatasetBuilder4(String name,
-                    Dataset<IN> input,
-                    UnaryFunction<IN, KEY> keyExtractor,
-                    UnaryFunction<IN, VALUE> valueExtractor,
-                    ReduceFunctor<VALUE, OUT> reducer,
-                    @Nullable BinaryFunction<VALUE, VALUE, Integer> valuesComparator) {
+    SortableDatasetBuilder4(
+        String name,
+        Dataset<IN> input,
+        UnaryFunction<IN, KEY> keyExtractor,
+        UnaryFunction<IN, VALUE> valueExtractor,
+        ReduceFunctor<VALUE, OUT> reducer,
+        @Nullable BinaryFunction<VALUE, VALUE, Integer> valuesComparator) {
 
       super(name, input, keyExtractor, valueExtractor, reducer, valuesComparator);
     }
@@ -302,32 +304,23 @@ public class ReduceByKey<IN, KEY, VALUE, OUT, W extends Window>
 
 
   public static class DatasetBuilder5<IN, KEY, VALUE, OUT, W extends Window>
+      extends DatasetBuilder4<IN, KEY, VALUE, OUT>
       implements Builders.OutputValues<KEY, OUT> {
-    private final String name;
-    private final Dataset<IN> input;
-    private final UnaryFunction<IN, KEY> keyExtractor;
-    private final UnaryFunction<IN, VALUE> valueExtractor;
-    private final ReduceFunctor<VALUE, OUT> reducer;
+
     @Nullable
     private final Windowing<IN, W> windowing;
-    @Nullable
-    private final BinaryFunction<VALUE, VALUE, Integer> valueComparator;
 
-    DatasetBuilder5(String name,
-                    Dataset<IN> input,
-                    UnaryFunction<IN, KEY> keyExtractor,
-                    UnaryFunction<IN, VALUE> valueExtractor,
-                    ReduceFunctor<VALUE, OUT> reducer,
-                    @Nullable Windowing<IN, W> windowing,
-                    @Nullable BinaryFunction<VALUE, VALUE, Integer> valueComparator) {
+    DatasetBuilder5(
+        String name,
+        Dataset<IN> input,
+        UnaryFunction<IN, KEY> keyExtractor,
+        UnaryFunction<IN, VALUE> valueExtractor,
+        ReduceFunctor<VALUE, OUT> reducer,
+        @Nullable Windowing<IN, W> windowing,
+        @Nullable BinaryFunction<VALUE, VALUE, Integer> valuesComparator) {
 
-      this.name = Objects.requireNonNull(name);
-      this.input = Objects.requireNonNull(input);
-      this.keyExtractor = Objects.requireNonNull(keyExtractor);
-      this.valueExtractor = Objects.requireNonNull(valueExtractor);
-      this.reducer = Objects.requireNonNull(reducer);
+      super(name, input, keyExtractor, valueExtractor, reducer, valuesComparator);
       this.windowing = windowing;
-      this.valueComparator = valueComparator;
     }
 
     @Override
@@ -335,7 +328,7 @@ public class ReduceByKey<IN, KEY, VALUE, OUT, W extends Window>
       Flow flow = input.getFlow();
       ReduceByKey<IN, KEY, VALUE, OUT, W> reduce = new ReduceByKey<>(
               name, flow, input, keyExtractor, valueExtractor,
-              windowing, reducer, valueComparator);
+              windowing, reducer, valuesComparator);
       flow.add(reduce);
       return reduce.output();
     }

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceStateByKey.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceStateByKey.java
@@ -228,14 +228,15 @@ public class ReduceStateByKey<
 
   public static class DatasetBuilder5<
       IN, KEY, VALUE, OUT, STATE extends State<VALUE, OUT>>
-      implements Builders.WindowBy<IN>, Builders.Output<Pair<KEY, OUT>>
-  {
-    private final String name;
-    private final Dataset<IN> input;
-    private final UnaryFunction<IN, KEY> keyExtractor;
-    private final UnaryFunction<IN, VALUE> valueExtractor;
-    private final StateFactory<VALUE, OUT, STATE> stateFactory;
-    private final StateMerger<VALUE, OUT, STATE> stateMerger;
+      implements Builders.WindowBy<IN, DatasetBuilder5<IN, KEY, VALUE, OUT, STATE>>,
+      Builders.Output<Pair<KEY, OUT>> {
+
+    final String name;
+    final Dataset<IN> input;
+    final UnaryFunction<IN, KEY> keyExtractor;
+    final UnaryFunction<IN, VALUE> valueExtractor;
+    final StateFactory<VALUE, OUT, STATE> stateFactory;
+    final StateMerger<VALUE, OUT, STATE> stateMerger;
 
     DatasetBuilder5(String name,
                     Dataset<IN> input,
@@ -269,16 +270,9 @@ public class ReduceStateByKey<
   }
 
   public static class DatasetBuilder6<
-          IN, KEY, VALUE, OUT, STATE extends State<VALUE, OUT>,
-          W extends Window>
-      implements Builders.Output<Pair<KEY, OUT>> {
+      IN, KEY, VALUE, OUT, STATE extends State<VALUE, OUT>, W extends Window>
+      extends DatasetBuilder5<IN, KEY, VALUE, OUT, STATE> {
 
-    private final String name;
-    private final Dataset<IN> input;
-    private final UnaryFunction<IN, KEY> keyExtractor;
-    private final UnaryFunction<IN, VALUE> valueExtractor;
-    private final StateFactory<VALUE, OUT, STATE> stateFactory;
-    private final StateMerger<VALUE, OUT, STATE> stateMerger;
     @Nullable
     private final Windowing<IN, W> windowing;
 
@@ -288,14 +282,8 @@ public class ReduceStateByKey<
                     UnaryFunction<IN, VALUE> valueExtractor,
                     StateFactory<VALUE, OUT, STATE> stateFactory,
                     StateMerger<VALUE, OUT, STATE> stateMerger,
-                    @Nullable Windowing<IN, W> windowing)
-    {
-      this.name = Objects.requireNonNull(name);
-      this.input = Objects.requireNonNull(input);
-      this.keyExtractor = Objects.requireNonNull(keyExtractor);
-      this.valueExtractor = Objects.requireNonNull(valueExtractor);
-      this.stateFactory = Objects.requireNonNull(stateFactory);
-      this.stateMerger = Objects.requireNonNull(stateMerger);
+                    @Nullable Windowing<IN, W> windowing) {
+      super(name, input, keyExtractor, valueExtractor, stateFactory, stateMerger);
       this.windowing = windowing;
     }
 

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceWindow.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/ReduceWindow.java
@@ -124,7 +124,7 @@ public class ReduceWindow<
   }
 
   public static class OutputBuilder<T, VALUE, OUT>
-      implements Builders.WindowBy<T>, OptionalMethodBuilder<OutputBuilder<T, VALUE, OUT>> {
+      implements Builders.WindowBy<T, OutputBuilder<T, VALUE, OUT>> {
 
     final String name;
     final Dataset<T> input;

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/SumByKey.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/SumByKey.java
@@ -81,12 +81,13 @@ public class SumByKey<IN, KEY, W extends Window>
     }
   }
   public static class ByBuilder2<IN, KEY>
-      implements Builders.WindowBy<IN>, Builders.Output<Pair<KEY, Long>>
-  {
-    private final String name;
-    private final Dataset<IN> input;
-    private final UnaryFunction<IN, KEY> keyExtractor;
-    private UnaryFunction<IN, Long> valueExtractor = e -> 1L;
+      implements Builders.WindowBy<IN, ByBuilder2<IN, KEY>>,
+      Builders.Output<Pair<KEY, Long>> {
+
+    final String name;
+    final Dataset<IN> input;
+    final UnaryFunction<IN, KEY> keyExtractor;
+    UnaryFunction<IN, Long> valueExtractor = e -> 1L;
 
     ByBuilder2(String name, Dataset<IN> input, UnaryFunction<IN, KEY> keyExtractor) {
       this.name = Objects.requireNonNull(name);
@@ -115,12 +116,7 @@ public class SumByKey<IN, KEY, W extends Window>
   }
 
   public static class OutputBuilder<IN, KEY, W extends Window>
-      implements Builders.Output<Pair<KEY, Long>>
-  {
-    private final String name;
-    private final Dataset<IN> input;
-    private final UnaryFunction<IN, KEY> keyExtractor;
-    private final UnaryFunction<IN, Long> valueExtractor;
+      extends ByBuilder2<IN, KEY> {
     @Nullable
     private final Windowing<IN, W> windowing;
 
@@ -129,9 +125,8 @@ public class SumByKey<IN, KEY, W extends Window>
                   UnaryFunction<IN, KEY> keyExtractor,
                   UnaryFunction<IN, Long> valueExtractor,
                   @Nullable Windowing<IN, W> windowing) {
-      this.name = Objects.requireNonNull(name);
-      this.input = Objects.requireNonNull(input);
-      this.keyExtractor = Objects.requireNonNull(keyExtractor);
+      
+      super(name, input, keyExtractor);
       this.valueExtractor = Objects.requireNonNull(valueExtractor);
       this.windowing = windowing;
     }

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/TopPerKey.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/TopPerKey.java
@@ -178,20 +178,22 @@ public class TopPerKey<
   }
 
   public static class WindowByBuilder<IN, K, V, S extends Comparable<S>>
-      implements Builders.WindowBy<IN>, Builders.Output<Triple<K, V, S>>
+      implements Builders.WindowBy<IN, WindowByBuilder<IN, K, V, S>>,
+      Builders.Output<Triple<K, V, S>>
   {
-    private String name;
-    private final Dataset<IN> input;
-    private final UnaryFunction<IN, K> keyFn;
-    private final UnaryFunction<IN, V> valueFn;
-    private final UnaryFunction<IN, S> scoreFn;
+    final String name;
+    final Dataset<IN> input;
+    final UnaryFunction<IN, K> keyFn;
+    final UnaryFunction<IN, V> valueFn;
+    final UnaryFunction<IN, S> scoreFn;
 
-    WindowByBuilder(String name,
-                    Dataset<IN> input,
-                    UnaryFunction<IN, K> keyFn,
-                    UnaryFunction<IN, V> valueFn,
-                    UnaryFunction<IN, S> scoreFn)
-    {
+    WindowByBuilder(
+        String name,
+        Dataset<IN> input,
+        UnaryFunction<IN, K> keyFn,
+        UnaryFunction<IN, V> valueFn,
+        UnaryFunction<IN, S> scoreFn) {
+
       this.name = requireNonNull(name);
       this.input = requireNonNull(input);
       this.keyFn = requireNonNull(keyFn);
@@ -216,13 +218,8 @@ public class TopPerKey<
 
   public static class OutputBuilder<
       IN, K, V, S extends Comparable<S>, W extends Window>
-      implements Builders.Output<Triple<K, V, S>>
-  {
-    private final String name;
-    private final Dataset<IN> input;
-    private final UnaryFunction<IN, K> keyFn;
-    private final UnaryFunction<IN, V> valueFn;
-    private final UnaryFunction<IN, S> scoreFn;
+      extends WindowByBuilder<IN, K, V, S> {
+
     @Nullable
     private final Windowing<IN, W> windowing;
 
@@ -233,11 +230,7 @@ public class TopPerKey<
                   UnaryFunction<IN, S> scoreFn,
                   @Nullable Windowing<IN, W> windowing) {
 
-      this.name = requireNonNull(name);
-      this.input = requireNonNull(input);
-      this.keyFn = requireNonNull(keyFn);
-      this.valueFn = requireNonNull(valueFn);
-      this.scoreFn = requireNonNull(scoreFn);
+      super(name, input, keyFn, valueFn, scoreFn);
       this.windowing = windowing;
     }
 

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/CountByKeyTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/CountByKeyTest.java
@@ -78,4 +78,19 @@ public class CountByKeyTest {
     assertTrue(count.getWindowing() instanceof Time);
   }
 
+  @Test
+  public void testWindow_applyIf() {
+    Flow flow = Flow.create("TEST");
+    Dataset<String> dataset = Util.createMockDataset(flow, 3);
+
+    CountByKey.named("CountByKey1")
+        .of(dataset)
+        .keyBy(s -> s)
+        .applyIf(true, b -> b.windowBy(Time.of(Duration.ofHours(1))))
+        .output();
+
+    CountByKey count = (CountByKey) flow.operators().iterator().next();
+    assertTrue(count.getWindowing() instanceof Time);
+  }
+
 }

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/DistinctTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/DistinctTest.java
@@ -72,4 +72,17 @@ public class DistinctTest {
     assertTrue(distinct.getWindowing() instanceof Time);
   }
 
+  @Test
+  public void testWindow_applyIf() {
+    Flow flow = Flow.create("TEST");
+    Dataset<String> dataset = Util.createMockDataset(flow, 3);
+
+    Distinct.of(dataset)
+        .applyIf(true, b -> b.windowBy(Time.of(Duration.ofHours(1))))
+        .output();
+
+    Distinct distinct = (Distinct) flow.operators().iterator().next();
+    assertTrue(distinct.getWindowing() instanceof Time);
+  }
+
 }

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/ReduceByKeyTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/ReduceByKeyTest.java
@@ -34,12 +34,12 @@ public class ReduceByKeyTest {
 
     Time<String> windowing = Time.of(Duration.ofHours(1));
     Dataset<Pair<String, Long>> reduced = ReduceByKey.named("ReduceByKey1")
-            .of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .combineBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
-            .windowBy(windowing)
-            .output();
+        .of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .combineBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
+        .windowBy(windowing)
+        .output();
 
     assertEquals(flow, reduced.getFlow());
     assertEquals(1, flow.size());
@@ -83,11 +83,11 @@ public class ReduceByKeyTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> dataset = Util.createMockDataset(flow, 2);
 
-    Dataset<Pair<String, Long>> reduced = ReduceByKey.of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .combineBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
-            .output();
+    ReduceByKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .combineBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
+        .output();
 
     ReduceByKey reduce = (ReduceByKey) flow.operators().iterator().next();
     assertEquals("ReduceByKey", reduce.getName());
@@ -98,11 +98,11 @@ public class ReduceByKeyTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> dataset = Util.createMockDataset(flow, 2);
 
-    Dataset<Pair<String, Long>> reduced = ReduceByKey.of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .reduceBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
-            .output();
+    ReduceByKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .reduceBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
+        .output();
 
     ReduceByKey reduce = (ReduceByKey) flow.operators().iterator().next();
     assertNotNull(reduce.reducer);
@@ -114,12 +114,12 @@ public class ReduceByKeyTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> dataset = Util.createMockDataset(flow, 2);
 
-    Dataset<Pair<String, Long>> reduced = ReduceByKey.of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .combineBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
-            .windowBy(Time.of(Duration.ofHours(1)))
-            .output();
+    ReduceByKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .combineBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
+        .windowBy(Time.of(Duration.ofHours(1)))
+        .output();
 
     ReduceByKey reduce = (ReduceByKey) flow.operators().iterator().next();
     assertTrue(reduce.getWindowing() instanceof Time);
@@ -131,13 +131,13 @@ public class ReduceByKeyTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> dataset = Util.createMockDataset(flow, 2);
 
-    Dataset<Pair<String, Long>> reduced = ReduceByKey.of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .reduceBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
-            .withSortedValues(Long::compare)
-            .windowBy(Time.of(Duration.ofHours(1)))
-            .output();
+    ReduceByKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .reduceBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
+        .withSortedValues(Long::compare)
+        .windowBy(Time.of(Duration.ofHours(1)))
+        .output();
 
     ReduceByKey reduce = (ReduceByKey) flow.operators().iterator().next();
     assertNotNull(reduce.valueComparator);
@@ -148,15 +148,32 @@ public class ReduceByKeyTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> dataset = Util.createMockDataset(flow, 2);
 
-    Dataset<Pair<String, Long>> reduced = ReduceByKey.of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .reduceBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
-            .withSortedValues(Long::compare)
-            .output();
+    ReduceByKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .reduceBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
+        .withSortedValues(Long::compare)
+        .output();
 
     ReduceByKey reduce = (ReduceByKey) flow.operators().iterator().next();
     assertNotNull(reduce.valueComparator);
+  }
+
+  @Test
+  public void testWindow_applyIf() {
+    Flow flow = Flow.create("TEST");
+    Dataset<String> dataset = Util.createMockDataset(flow, 2);
+
+    ReduceByKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .reduceBy(n -> StreamSupport.stream(n.spliterator(), false).mapToLong(Long::new).sum())
+        .withSortedValues(Long::compare)
+        .applyIf(true, b -> b.windowBy(Time.of(Duration.ofHours(1))))
+        .output();
+
+    ReduceByKey reduce = (ReduceByKey) flow.operators().iterator().next();
+    assertTrue(reduce.getWindowing() instanceof Time);
   }
 
 }

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/ReduceStateByKeyTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/ReduceStateByKeyTest.java
@@ -39,13 +39,13 @@ public class ReduceStateByKeyTest {
 
     Time<String> windowing = Time.of(Duration.ofHours(1));
     Dataset<Pair<String, Long>> reduced = ReduceStateByKey.named("ReduceStateByKey1")
-            .of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .stateFactory(WordCountState::new)
-            .mergeStatesBy(WordCountState::combine)
-            .windowBy(windowing)
-            .output();
+        .of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .stateFactory(WordCountState::new)
+        .mergeStatesBy(WordCountState::combine)
+        .windowBy(windowing)
+        .output();
 
     assertEquals(flow, reduced.getFlow());
     assertEquals(1, flow.size());
@@ -66,12 +66,12 @@ public class ReduceStateByKeyTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> dataset = Util.createMockDataset(flow, 2);
 
-    Dataset<Pair<String, Long>> reduced = ReduceStateByKey.of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .stateFactory(WordCountState::new)
-            .mergeStatesBy(WordCountState::combine)
-            .output();
+    ReduceStateByKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .stateFactory(WordCountState::new)
+        .mergeStatesBy(WordCountState::combine)
+        .output();
 
     ReduceStateByKey reduce = (ReduceStateByKey) flow.operators().iterator().next();
     assertEquals("ReduceStateByKey", reduce.getName());
@@ -89,6 +89,23 @@ public class ReduceStateByKeyTest {
             .mergeStatesBy(WordCountState::combine)
             .windowBy(Time.of(Duration.ofHours(1)))
             .output();
+
+    ReduceStateByKey reduce = (ReduceStateByKey) flow.operators().iterator().next();
+    assertTrue(reduce.getWindowing() instanceof Time);
+  }
+
+  @Test
+  public void testWindow_applyIf() {
+    Flow flow = Flow.create("TEST");
+    Dataset<String> dataset = Util.createMockDataset(flow, 2);
+
+    ReduceStateByKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .stateFactory(WordCountState::new)
+        .mergeStatesBy(WordCountState::combine)
+        .applyIf(true, b -> b.windowBy(Time.of(Duration.ofHours(1))))
+        .output();
 
     ReduceStateByKey reduce = (ReduceStateByKey) flow.operators().iterator().next();
     assertTrue(reduce.getWindowing() instanceof Time);
@@ -127,4 +144,5 @@ public class ReduceStateByKeyTest {
       sum.clear();
     }
   }
+
 }

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/ReduceWindowTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/ReduceWindowTest.java
@@ -89,6 +89,22 @@ public class ReduceWindowTest {
     assertNotNull(producer.valueComparator);
   }
 
+  @Test
+  public void testWindow_applyIf() {
+    Flow flow = Flow.create("TEST");
+    Dataset<String> dataset = Util.createMockDataset(flow, 2);
+    Windowing<String, ?> windowing = Time.of(Duration.ofHours(1));
+
+    Dataset<Long> output = ReduceWindow.of(dataset)
+        .reduceBy(e -> 1L)
+        .withSortedValues((l, r) -> l.compareTo(r))
+        .applyIf(true, b -> b.windowBy(windowing))
+        .output();
+    
+    ReduceWindow<String, String, Long, ?> producer;
+    producer = (ReduceWindow<String, String, Long, ?>) output.getProducer();
+    assertTrue(producer.windowing instanceof Time);
+  }
 
   private <IN, OUT> OUT collectSingle(
       ReduceFunctor<IN, OUT> fn, Stream<IN> values) {

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/SumByKeyTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/SumByKeyTest.java
@@ -32,9 +32,9 @@ public class SumByKeyTest {
     Dataset<String> dataset = Util.createMockDataset(flow, 3);
 
     Dataset<Pair<String, Long>> counted = SumByKey.named("SumByKey1")
-            .of(dataset)
-            .keyBy(s -> s)
-            .output();
+        .of(dataset)
+        .keyBy(s -> s)
+        .output();
 
     assertEquals(flow, counted.getFlow());
     assertEquals(1, flow.size());
@@ -52,9 +52,9 @@ public class SumByKeyTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> dataset = Util.createMockDataset(flow, 3);
 
-    Dataset<Pair<String, Long>> counted = SumByKey.of(dataset)
-            .keyBy(s -> s)
-            .output();
+    SumByKey.of(dataset)
+        .keyBy(s -> s)
+        .output();
 
     SumByKey sum = (SumByKey) flow.operators().iterator().next();
     assertEquals("SumByKey", sum.getName());
@@ -65,11 +65,26 @@ public class SumByKeyTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> dataset = Util.createMockDataset(flow, 3);
 
-    Dataset<Pair<String, Long>> counted = SumByKey.of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .windowBy(Time.of(Duration.ofHours(1)))
-            .output();
+    SumByKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .windowBy(Time.of(Duration.ofHours(1)))
+        .output();
+
+    SumByKey sum = (SumByKey) flow.operators().iterator().next();
+    assertTrue(sum.getWindowing() instanceof Time);
+  }
+
+  @Test
+  public void testWindow_applyIf() {
+    Flow flow = Flow.create("TEST");
+    Dataset<String> dataset = Util.createMockDataset(flow, 3);
+
+    SumByKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .applyIf(true, b -> b.windowBy(Time.of(Duration.ofHours(1))))
+        .output();
 
     SumByKey sum = (SumByKey) flow.operators().iterator().next();
     assertTrue(sum.getWindowing() instanceof Time);

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/TopPerKeyTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/client/operator/TopPerKeyTest.java
@@ -34,12 +34,12 @@ public class TopPerKeyTest {
 
     Time<String> windowing = Time.of(Duration.ofHours(1));
     Dataset<Triple<String, Long, Long>> result = TopPerKey.named("TopPerKey1")
-            .of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .scoreBy(s -> 1L)
-            .windowBy(windowing)
-            .output();
+        .of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .scoreBy(s -> 1L)
+        .windowBy(windowing)
+        .output();
 
     assertEquals(flow, result.getFlow());
     assertEquals(1, flow.size());
@@ -59,11 +59,11 @@ public class TopPerKeyTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> dataset = Util.createMockDataset(flow, 2);
 
-    Dataset<Triple<String, Long, Long>> result = TopPerKey.of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .scoreBy(s -> 1L)
-            .output();
+    TopPerKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .scoreBy(s -> 1L)
+        .output();
 
     TopPerKey tpk = (TopPerKey) Iterables.getOnlyElement(flow.operators());
     assertEquals("TopPerKey", tpk.getName());
@@ -74,14 +74,30 @@ public class TopPerKeyTest {
     Flow flow = Flow.create("TEST");
     Dataset<String> dataset = Util.createMockDataset(flow, 3);
 
-    Dataset<Triple<String, Long, Long>> result = TopPerKey.of(dataset)
-            .keyBy(s -> s)
-            .valueBy(s -> 1L)
-            .scoreBy(s -> 1L)
-            .windowBy(Time.of(Duration.ofHours(1)))
-            .output();
+    TopPerKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .scoreBy(s -> 1L)
+        .windowBy(Time.of(Duration.ofHours(1)))
+        .output();
 
+    assertTrue(Iterables.getOnlyElement(flow.operators()) instanceof TopPerKey);
+  }
+
+  @Test
+  public void testWindow_applyIf() {
+    Flow flow = Flow.create("TEST");
+    Dataset<String> dataset = Util.createMockDataset(flow, 3);
+
+    TopPerKey.of(dataset)
+        .keyBy(s -> s)
+        .valueBy(s -> 1L)
+        .scoreBy(s -> 1L)
+        .applyIf(true, b -> b.windowBy(Time.of(Duration.ofHours(1))))
+        .output();
+    
     TopPerKey tpk = (TopPerKey) Iterables.getOnlyElement(flow.operators());
+    assertTrue(tpk.windowing instanceof Time);
   }
 
 }


### PR DESCRIPTION
Purpose of this PR is to make sure, that every call to `windowBy` can be wrapped into `applyIf()` call. This is very handy for cases when you have optional windowing strategy for a RSBK type operation, e.g.
```java
  @Nullable Windowing windowing = ...;
  ReduceByKey.of(...)
    .keyBy(..)
    ...
    .applyIf(windowing != null, b -> b.windowBy(windowing))
    .output();
```

The alternative approach would be either:
 * enable passing `null` to `windowBy` and handle it there, which seems unclean
 * let it to the user to work with the builders, storing them to intermediate variables and branching the code himself, which is just ugly

This PR implies that the result build of `applyIf` and `windowBy` is the same, which has some implications that are not very nice - i.e. you can apply `windowBy` multiple times, but that is tolerable imo.