### PR TITLE
Added PrefetchIterator

### DIFF
--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/util/PrefetchIterator.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/util/PrefetchIterator.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2016-2017 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.core.util;
+
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * Iterator wrapper allowing to look at next value using {@link #prefetch()}
+ * without moving the iterator forward, so following call of {@link #next()}
+ * will return the same value.
+ */
+public class PrefetchIterator<T> implements Iterator<T> {
+  private final Iterator<T> it;
+  private T prefetched = null;
+
+  public PrefetchIterator(Iterator<T> src) {
+    it = src;
+  }
+  public PrefetchIterator(Stream<T> src) {
+    this(src.iterator());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean hasNext() {
+    return prefetched != null || it.hasNext();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public T next() {
+    if (prefetched != null) {
+      T ret = prefetched;
+      prefetched = null;
+      return ret;
+    } else {
+      return it.next();
+    }
+  }
+
+  /**
+   * Get next value without moving the iterator forward.
+   *
+   * @return Next value (or null on the end)
+   */
+  public T prefetch() {
+    if (prefetched == null && it.hasNext())
+      prefetched = it.next();
+    return prefetched;
+  }
+}

--- a/euphoria-core/src/test/java/cz/seznam/euphoria/core/util/PrefetchIteratorTest.java
+++ b/euphoria-core/src/test/java/cz/seznam/euphoria/core/util/PrefetchIteratorTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2016-2017 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.core.util;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
+
+public class PrefetchIteratorTest {
+
+  @Test
+  public void testEmpty() {
+    List<Integer> list = Collections.emptyList();
+    PrefetchIterator<Integer> it = new PrefetchIterator<>(list.iterator());
+
+    assertNull(it.prefetch());
+    assertFalse(it.hasNext());
+  }
+
+  @Test
+  public void testSingle() {
+    List<Integer> list = Collections.singletonList(5);
+    PrefetchIterator<Integer> it = new PrefetchIterator<>(list.iterator());
+
+    assertEquals(Integer.valueOf(5), it.prefetch());
+    assertTrue(it.hasNext());
+    assertEquals(Integer.valueOf(5), it.next());
+  }
+
+  @Test
+  public void testLong() {
+    List<Integer> list = Arrays.asList(1, 2, 3, 4, 5);
+    PrefetchIterator<Integer> it = new PrefetchIterator<>(list.iterator());
+
+    for (Integer expected: list) {
+      assertEquals(expected, it.prefetch());
+      assertTrue(it.hasNext());
+      assertEquals(expected, it.next());
+    }
+
+    assertFalse(it.hasNext());
+  }
+}
+


### PR DESCRIPTION
Useful for construct like:
```java
Dataset<T> data = Join.of(input, config)...;
ReduceByKey.of(data)
  .reduceBy((Stream<T> values, Collector<X> collector) -> {
    final PrefetchIterator<T> iterator = new PrefetchIterator<>(values);
    T first = iterator.prefetch();
    if (first != null) {
      if (first.selected())
        processSelected(iterator, collector);
      else
        processUnselected(iterator, collector);
    }
  });
```