### PR TITLE
broadcastHashJoin fix

### DIFF
--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/hint/Util.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/hint/Util.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2018 Seznam.cz, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.seznam.euphoria.core.client.operator.hint;
+
+import cz.seznam.euphoria.core.client.dataset.Dataset;
+import cz.seznam.euphoria.core.client.dataset.windowing.MergingWindowing;
+import cz.seznam.euphoria.core.client.operator.Join;
+import cz.seznam.euphoria.core.client.operator.Operator;
+
+import java.util.ArrayList;
+
+public class Util {
+
+  @SuppressWarnings("unchecked")
+  public static boolean wantTranslateBroadcastHashJoin(Join o) {
+    final ArrayList<Dataset> inputs = new ArrayList(o.listInputs());
+    if (inputs.size() != 2) {
+      return false;
+    }
+    final Dataset leftDataset = inputs.get(0);
+    final Dataset rightDataset = inputs.get(1);
+    return
+        (o.getType() == Join.Type.LEFT && hasFitsInMemoryHint(rightDataset.getProducer()) ||
+            o.getType() == Join.Type.RIGHT && hasFitsInMemoryHint(leftDataset.getProducer())
+        ) && !(o.getWindowing() instanceof MergingWindowing);
+  }
+
+  public static boolean hasFitsInMemoryHint(Operator operator) {
+    return operator != null &&
+        operator.getHints() != null &&
+        operator.getHints().contains(SizeHint.FITS_IN_MEMORY);
+  }
+}

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/executor/util/OperatorTranslator.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/executor/util/OperatorTranslator.java
@@ -13,16 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package cz.seznam.euphoria.core.client.operator.hint;
+package cz.seznam.euphoria.core.executor.util;
 
+import cz.seznam.euphoria.core.annotation.audience.Audience;
 import cz.seznam.euphoria.core.client.dataset.Dataset;
 import cz.seznam.euphoria.core.client.dataset.windowing.MergingWindowing;
 import cz.seznam.euphoria.core.client.operator.Join;
 import cz.seznam.euphoria.core.client.operator.Operator;
+import cz.seznam.euphoria.core.client.operator.hint.SizeHint;
 
 import java.util.ArrayList;
 
-public class Util {
+/**
+ * Util class when specific executors use the same methods for operator translation
+ */
+@Audience(Audience.Type.EXECUTOR)
+public class OperatorTranslator {
 
   @SuppressWarnings("unchecked")
   public static boolean wantTranslateBroadcastHashJoin(Join o) {

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/BroadcastHashJoinTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/BroadcastHashJoinTranslator.java
@@ -34,7 +34,7 @@ import org.apache.flink.util.Collector;
 import java.util.List;
 import java.util.Objects;
 
-import static cz.seznam.euphoria.core.client.operator.hint.Util.wantTranslateBroadcastHashJoin;
+import static cz.seznam.euphoria.core.executor.util.OperatorTranslator.wantTranslateBroadcastHashJoin;
 
 public class BroadcastHashJoinTranslator implements BatchOperatorTranslator<Join> {
 

--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/BroadcastHashJoinTranslator.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/batch/BroadcastHashJoinTranslator.java
@@ -15,15 +15,11 @@
  */
 package cz.seznam.euphoria.flink.batch;
 
-import cz.seznam.euphoria.core.client.dataset.Dataset;
-import cz.seznam.euphoria.core.client.dataset.windowing.MergingWindowing;
 import cz.seznam.euphoria.core.client.dataset.windowing.Window;
 import cz.seznam.euphoria.core.client.dataset.windowing.Windowing;
 import cz.seznam.euphoria.core.client.functional.BinaryFunctor;
 import cz.seznam.euphoria.core.client.functional.UnaryFunction;
 import cz.seznam.euphoria.core.client.operator.Join;
-import cz.seznam.euphoria.core.client.operator.Operator;
-import cz.seznam.euphoria.core.client.operator.hint.SizeHint;
 import cz.seznam.euphoria.core.client.util.Pair;
 import cz.seznam.euphoria.core.executor.util.MultiValueContext;
 import cz.seznam.euphoria.flink.FlinkOperator;
@@ -38,22 +34,13 @@ import org.apache.flink.util.Collector;
 import java.util.List;
 import java.util.Objects;
 
+import static cz.seznam.euphoria.core.client.operator.hint.Util.wantTranslateBroadcastHashJoin;
+
 public class BroadcastHashJoinTranslator implements BatchOperatorTranslator<Join> {
 
-  @SuppressWarnings("unchecked")
+
   static boolean wantTranslate(Join o) {
-
-    return o.listInputs()
-        .stream()
-        .anyMatch(input -> hasSizeHint(((Dataset) input).getProducer()))
-        && (o.getType() == Join.Type.LEFT || o.getType() == Join.Type.RIGHT)
-        && !(o.getWindowing() instanceof MergingWindowing);
-  }
-
-  static boolean hasSizeHint(Operator operator) {
-    return operator != null &&
-        operator.getHints() != null &&
-        operator.getHints().contains(SizeHint.FITS_IN_MEMORY);
+    return wantTranslateBroadcastHashJoin(o);
   }
 
   @Override

--- a/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/BroadcastHashJoinTranslator.java
+++ b/euphoria-spark/src/main/java/cz/seznam/euphoria/spark/BroadcastHashJoinTranslator.java
@@ -40,8 +40,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static cz.seznam.euphoria.core.client.operator.hint.Util.hasFitsInMemoryHint;
-import static cz.seznam.euphoria.core.client.operator.hint.Util.wantTranslateBroadcastHashJoin;
+import static cz.seznam.euphoria.core.executor.util.OperatorTranslator.hasFitsInMemoryHint;
+import static cz.seznam.euphoria.core.executor.util.OperatorTranslator.wantTranslateBroadcastHashJoin;
 
 /**
  * <p>


### PR DESCRIPTION
`BroadcastHashJoin` translator was used even when wrong side had `SizeHint.FITS_IN_MEMORY`. (E.g.  in `LeftJoin` only right side with hint should translate to `BroadcastHashJoin` and vice versa)