### PR TITLE
Remove duplicated part in constructor

### DIFF
--- a/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/FlinkExecutor.java
+++ b/euphoria-flink/src/main/java/cz/seznam/euphoria/flink/FlinkExecutor.java
@@ -287,15 +287,14 @@ public class FlinkExecutor implements Executor {
    * @return this instance (for method chaining purposes)
    */
   public FlinkExecutor registerClass(Class<?> cls) {
-    registeredClasses.put(cls, null);
-    return this;
+    return this.registerClass(cls, null);
   }
 
   /**
    * Pre-register given class to flink for serialization purposes.
    *
    * @param cls the type of objects which flink is supposed to serialize/deserialize
-   * @param classSeriliazer serilizer
+   * @param classSeriliazer serializer
    * @return this instance (for method chaining purposes)
    */
   public FlinkExecutor registerClass(Class<?> cls, Class<? extends Serializer> classSeriliazer) {


### PR DESCRIPTION
There are some overloading method, so I merged some duplicate part.
Also typo `classSeriliazer` seems wrong, but I'm not sure to fix it because maybe it could be documented and being used somewhere...

Please look and feel free to comment if there is any problem.