### PR TITLE
optional setting of LazyOutputFormat for HadoopSink

### DIFF
--- a/euphoria-hadoop/src/main/java/cz/seznam/euphoria/hadoop/output/HadoopSink.java
+++ b/euphoria-hadoop/src/main/java/cz/seznam/euphoria/hadoop/output/HadoopSink.java
@@ -59,6 +59,8 @@ public class HadoopSink<K, V> implements DataSink<Pair<K, V>> {
   public HadoopSink(Class<? extends OutputFormat<K, V>> outputFormatClass,
       Configuration conf, boolean useLazyOutputFormat) {
     Objects.requireNonNull(outputFormatClass);
+    Objects.requireNonNull(conf);
+
     if (useLazyOutputFormat) {
       this.outputFormatClass = (Class) LazyOutputFormat.class;
       conf.setClass(LazyOutputFormat.OUTPUT_FORMAT, outputFormatClass, OutputFormat.class);
@@ -66,7 +68,7 @@ public class HadoopSink<K, V> implements DataSink<Pair<K, V>> {
       this.outputFormatClass = outputFormatClass;
     }
 
-    this.conf = new SerializableWritable<>(Objects.requireNonNull(conf));
+    this.conf = new SerializableWritable<>(conf);
     this.jobID = new SerializableWritable<>(HadoopUtils.getJobID());
   }
 

--- a/euphoria-hadoop/src/main/java/cz/seznam/euphoria/hadoop/output/HadoopTextFileSink.java
+++ b/euphoria-hadoop/src/main/java/cz/seznam/euphoria/hadoop/output/HadoopTextFileSink.java
@@ -42,7 +42,8 @@ public class HadoopTextFileSink<K, V> extends HadoopSink<K, V> {
   /**
    * Constructs a data sink based on hadoop's {@link TextOutputFormat}.
    * The specified path is automatically set/overridden in the given hadoop
-   * configuration.
+   * configuration. Writer can create empty files
+   * ({@link org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat} is not used).
    *
    * @param path the path to read data from
    * @param hadoopConfig the hadoop configuration to build on top of
@@ -51,7 +52,22 @@ public class HadoopTextFileSink<K, V> extends HadoopSink<K, V> {
    */
   @SuppressWarnings("unchecked")
   public HadoopTextFileSink(String path, Configuration hadoopConfig) {
-    super((Class) TextOutputFormat.class, hadoopConfig);
+    this(path, hadoopConfig, false);
+  }
+
+  /**
+   * Constructs a data sink based on hadoop's {@link TextOutputFormat}. The specified path is
+   * automatically set/overridden in the given hadoop configuration.
+   *
+   * @param path the path to read data from
+   * @param hadoopConfig the hadoop configuration to build on top of
+   * @param useLazyOutputFormat whether to use {@link
+   *     org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat} (won't create empty files)
+   * @throws NullPointerException if any of the parameters is {@code null}
+   */
+  @SuppressWarnings("unchecked")
+  public HadoopTextFileSink(String path, Configuration hadoopConfig, boolean useLazyOutputFormat) {
+    super((Class) TextOutputFormat.class, hadoopConfig, useLazyOutputFormat);
     hadoopConfig.set(FileOutputFormat.OUTDIR, path);
   }
 }

--- a/euphoria-hadoop/src/main/java/cz/seznam/euphoria/hadoop/output/HadoopToStringSink.java
+++ b/euphoria-hadoop/src/main/java/cz/seznam/euphoria/hadoop/output/HadoopToStringSink.java
@@ -49,7 +49,8 @@ public class HadoopToStringSink<T> implements DataSink<T> {
   /**
    * Constructs a data sink based on hadoop's {@link TextOutputFormat}.
    * The specified path is automatically set/overridden in the given hadoop
-   * configuration.
+   * configuration. Writer can create empty files
+   * ({@link org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat} is not used).
    *
    * @param path the path to read data from
    * @param hadoopConfig the hadoop configuration to build on top of
@@ -58,7 +59,22 @@ public class HadoopToStringSink<T> implements DataSink<T> {
    */
   @SuppressWarnings("unchecked")
   public HadoopToStringSink(String path, Configuration hadoopConfig) {
-    impl = new HadoopTextFileSink<>(path, hadoopConfig);
+    this(path, hadoopConfig, false);
+  }
+
+  /**
+   * Constructs a data sink based on hadoop's {@link TextOutputFormat}. The specified path is
+   * automatically set/overridden in the given hadoop configuration.
+   *
+   * @param path the path to read data from
+   * @param hadoopConfig the hadoop configuration to build on top of
+   * @param useLazyOutputFormat whether to use {@link
+   *     org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat} (won't create empty files)
+   * @throws NullPointerException if any of the parameters is {@code null}
+   */
+  @SuppressWarnings("unchecked")
+  public HadoopToStringSink(String path, Configuration hadoopConfig, boolean useLazyOutputFormat) {
+    impl = new HadoopTextFileSink<>(path, hadoopConfig, useLazyOutputFormat);
   }
 
   @Override

--- a/euphoria-hadoop/src/main/java/cz/seznam/euphoria/hadoop/output/SequenceFileSink.java
+++ b/euphoria-hadoop/src/main/java/cz/seznam/euphoria/hadoop/output/SequenceFileSink.java
@@ -17,6 +17,7 @@ package cz.seznam.euphoria.hadoop.output;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.SequenceFile.CompressionType;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
@@ -33,9 +34,9 @@ import javax.annotation.Nullable;
  * SequenceFileSink
  *    .of(KeyClass, ValueClass)
  *    .outputPath(outputDir)
+ *    .withLazyOutputFormat() // optional (must be before withConfiguration)
  *    .withConfiguration( hadoopConfig) // optional (must be before withCompression)
  *    .withCompression( CompressionClass, CompressionType) //optional
- *    .withLazyOutputFormat() // optional
  *    .build();
  * }</pre>
  *
@@ -69,8 +70,58 @@ public class SequenceFileSink<K, V> extends HadoopSink<K, V> {
      * @param outputPath the destination where to save the output
      * @return Builder with optional setters
      */
-    public WithConfigurationBuilder<K, V> outputPath(String outputPath) {
-      return new WithConfigurationBuilder<>(keyClass, valueClass, outputPath);
+    public WithLazyOutputFormatBuilder<K, V> outputPath(String outputPath) {
+      return new WithLazyOutputFormatBuilder<>(keyClass, valueClass, outputPath);
+    }
+  }
+
+  public static class WithLazyOutputFormatBuilder<K, V> {
+
+    private final Class<K> keyClass;
+    private final Class<V> valueClass;
+    private final String outputPath;
+
+    WithLazyOutputFormatBuilder(Class<K> keyClass, Class<V> valueClass, String outputPath) {
+      this.keyClass = keyClass;
+      this.valueClass = valueClass;
+      this.outputPath = outputPath;
+    }
+
+    /**
+     * Optional setter for {@link org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat}. If used,
+     * {@link SequenceFileOutputFormat} won't create empty files. Default value is false;
+     *
+     * @return this instance of SinkBuilder
+     */
+    public WithConfigurationBuilder<K, V> withLazyOutputFormat() {
+      return new WithConfigurationBuilder<>(keyClass, valueClass, outputPath, true);
+    }
+
+    /**
+     * Optional setter if not used it will be created new hadoop configuration.
+     *
+     * @param configuration the hadoop configuration to build on top of
+     * @return Builder
+     */
+    public WithCompressionBuilder<K, V> withConfiguration(Configuration configuration) {
+      return new WithCompressionBuilder<>(keyClass, valueClass, outputPath, false, configuration);
+    }
+
+    /**
+     * Optional setter for compression
+     *
+     * @param compressionClass COMPRESS_CODEC class
+     * @param compressionType COMPRESS_TYPE value
+     * @return Builder
+     */
+    public SinkBuilder<K, V> withCompression(
+        Class<? extends CompressionCodec> compressionClass,
+        SequenceFile.CompressionType compressionType) {
+      return withConfiguration(null).withCompression(compressionClass, compressionType);
+    }
+
+    public SequenceFileSink<K, V> build() {
+      return withConfiguration(null).withCompression(null, null).build();
     }
   }
 
@@ -79,14 +130,17 @@ public class SequenceFileSink<K, V> extends HadoopSink<K, V> {
     private final Class<K> keyClass;
     private final Class<V> valueClass;
     private final String outputPath;
+    private final boolean useLazyOutputFormat;
 
     WithConfigurationBuilder(
         Class<K> keyClass,
         Class<V> valueType,
-        String outputPath) {
+        String outputPath,
+        boolean useLazyOutputFormat) {
       this.keyClass = keyClass;
       this.valueClass = valueType;
       this.outputPath = outputPath;
+      this.useLazyOutputFormat = useLazyOutputFormat;
     }
 
     /**
@@ -95,7 +149,8 @@ public class SequenceFileSink<K, V> extends HadoopSink<K, V> {
      * @return Builder
      */
     public WithCompressionBuilder<K, V> withConfiguration(Configuration configuration) {
-      return new WithCompressionBuilder<>(keyClass, valueClass, outputPath, configuration);
+      return new WithCompressionBuilder<>(keyClass, valueClass, outputPath, useLazyOutputFormat,
+          configuration);
     }
 
     /**
@@ -120,6 +175,7 @@ public class SequenceFileSink<K, V> extends HadoopSink<K, V> {
     private final Class<K> keyType;
     private final Class<V> valueType;
     private final String outputPath;
+    private final boolean useLazyOutputFormat;
     @Nullable
     private final Configuration configuration;
 
@@ -127,10 +183,12 @@ public class SequenceFileSink<K, V> extends HadoopSink<K, V> {
         Class<K> keyType,
         Class<V> valueType,
         String outputPath,
+        boolean useLazyOutputFormat,
         @Nullable Configuration configuration) {
       this.keyType = keyType;
       this.valueType = valueType;
       this.outputPath = outputPath;
+      this.useLazyOutputFormat = useLazyOutputFormat;
       this.configuration = configuration;
     }
 
@@ -147,7 +205,7 @@ public class SequenceFileSink<K, V> extends HadoopSink<K, V> {
           keyType,
           valueType,
           outputPath,
-          configuration,
+          useLazyOutputFormat, configuration,
           compressionClass,
           compressionType);
     }
@@ -163,40 +221,31 @@ public class SequenceFileSink<K, V> extends HadoopSink<K, V> {
     private final Class<K> keyClass;
     private final Class<V> valueType;
     private final String outputPath;
+    private final boolean useLazyOutputFormat;
     @Nullable
     private final Configuration configuration;
     @Nullable
     private final Class<? extends CompressionCodec> compressionClass;
     @Nullable
     private final SequenceFile.CompressionType compressionType;
-    private boolean useLazyOutputFormat = false;
 
     SinkBuilder(
         Class<K> keyClass,
         Class<V> valueType,
         String outputPath,
+        boolean useLazyOutputFormat,
         @Nullable Configuration configuration,
         @Nullable Class<? extends CompressionCodec> compressionClass,
-        @Nullable SequenceFile.CompressionType compressionType
+        @Nullable CompressionType compressionType
     ) {
 
       this.keyClass = keyClass;
       this.valueType = valueType;
       this.outputPath = outputPath;
+      this.useLazyOutputFormat = useLazyOutputFormat;
       this.configuration = configuration;
       this.compressionClass = compressionClass;
       this.compressionType = compressionType;
-    }
-
-    /**
-     * Optional setter for {@link org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat}. If used,
-     * {@link SequenceFileOutputFormat} won't create empty files. Default value is false;
-     *
-     * @return this instance of SinkBuilder
-     */
-    public SinkBuilder withLazyOutputFormat() {
-      this.useLazyOutputFormat = true;
-      return this;
     }
 
     public SequenceFileSink<K, V> build() {

--- a/euphoria-hadoop/src/main/java/cz/seznam/euphoria/hadoop/output/SimpleHadoopTextFileSink.java
+++ b/euphoria-hadoop/src/main/java/cz/seznam/euphoria/hadoop/output/SimpleHadoopTextFileSink.java
@@ -76,7 +76,8 @@ public class SimpleHadoopTextFileSink<V> implements DataSink<V> {
   /**
    * Constructs a data sink based on {@link HadoopTextFileSink}.
    * The specified path is automatically set/overridden in the given hadoop
-   * configuration.
+   * configuration. Writer can create empty files
+   * ({@link org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat} is not used).
    *
    * @param path the path to read data from
    * @param hadoopConfig the hadoop configuration to build on top of
@@ -85,7 +86,23 @@ public class SimpleHadoopTextFileSink<V> implements DataSink<V> {
    */
   @SuppressWarnings("unchecked")
   public SimpleHadoopTextFileSink(String path, Configuration hadoopConfig) {
-    this.wrap = new HadoopTextFileSink<>(path, hadoopConfig);
+    this(path, hadoopConfig, false);
+  }
+
+  /**
+   * Constructs a data sink based on {@link HadoopTextFileSink}. The specified path is automatically
+   * set/overridden in the given hadoop configuration.
+   *
+   * @param path the path to read data from
+   * @param hadoopConfig the hadoop configuration to build on top of
+   * @param useLazyOutputFormat whether to use {@link
+   *     org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat} (won't create empty files)
+   * @throws NullPointerException if any of the parameters is {@code null}
+   */
+  @SuppressWarnings("unchecked")
+  public SimpleHadoopTextFileSink(
+      String path, Configuration hadoopConfig, boolean useLazyOutputFormat) {
+    this.wrap = new HadoopTextFileSink<>(path, hadoopConfig, useLazyOutputFormat);
   }
 
   @Override

--- a/euphoria-hadoop/src/test/java/cz/seznam/euphoria/hadoop/output/HadoopSinkTest.java
+++ b/euphoria-hadoop/src/test/java/cz/seznam/euphoria/hadoop/output/HadoopSinkTest.java
@@ -76,7 +76,7 @@ public class HadoopSinkTest<I, O, S extends DataSource<I>, T extends DataSink<I>
   public static List<Object[]> testParameters() {
     return Arrays.asList(
         new Object[][] {
-          // DataSinkTester, useLazyOutputFormat, expectedNumberOfReduceOutputs
+          // testName, DataSinkTester, useLazyOutputFormat, expectedNumberOfReduceOutputs
           {"SequenceFileSink", new SequenceFileSinkTester(), false, 5},
           {"SequenceFileSink - lazy", new SequenceFileSinkTester(), true, 4},
           {"HadoopTextFileSink", new HadoopTextFileSinkTester(), false, 5},
@@ -181,14 +181,20 @@ public class HadoopSinkTest<I, O, S extends DataSource<I>, T extends DataSink<I>
     @Override
     public SequenceFileSink<Text, LongWritable> buildSink(
         String outputDir, Configuration conf, boolean useLazyOutputFormat) {
-      SinkBuilder<Text, LongWritable> sinkBuilder =
-          SequenceFileSink.of(Text.class, LongWritable.class)
-              .outputPath(outputDir)
-              .withConfiguration(conf)
-              .withCompression(DeflateCodec.class, SequenceFile.CompressionType.BLOCK);
+      final SequenceFileSink.WithLazyOutputFormatBuilder<Text, LongWritable>
+          withLazyOutputFormatBuilder =
+              SequenceFileSink.of(Text.class, LongWritable.class).outputPath(outputDir);
+      final SequenceFileSink.WithCompressionBuilder<Text, LongWritable> withCompressionBuilder;
       if (useLazyOutputFormat) {
-        sinkBuilder = sinkBuilder.withLazyOutputFormat();
+        withCompressionBuilder =
+            withLazyOutputFormatBuilder.withLazyOutputFormat().withConfiguration(conf);
+      } else {
+        withCompressionBuilder = withLazyOutputFormatBuilder.withConfiguration(conf);
       }
+      SinkBuilder<Text, LongWritable> sinkBuilder =
+          withCompressionBuilder.withCompression(
+              DeflateCodec.class, SequenceFile.CompressionType.BLOCK);
+
       return sinkBuilder.build();
     }
 

--- a/euphoria-hadoop/src/test/java/cz/seznam/euphoria/hadoop/output/HadoopSinkTest.java
+++ b/euphoria-hadoop/src/test/java/cz/seznam/euphoria/hadoop/output/HadoopSinkTest.java
@@ -16,6 +16,7 @@
 package cz.seznam.euphoria.hadoop.output;
 
 import cz.seznam.euphoria.core.client.flow.Flow;
+import cz.seznam.euphoria.core.client.io.DataSink;
 import cz.seznam.euphoria.core.client.io.DataSource;
 import cz.seznam.euphoria.core.client.io.ListDataSource;
 import cz.seznam.euphoria.core.client.operator.MapElements;
@@ -24,7 +25,11 @@ import cz.seznam.euphoria.core.executor.Executor;
 import cz.seznam.euphoria.core.util.ExceptionUtils;
 import cz.seznam.euphoria.executor.local.LocalExecutor;
 import cz.seznam.euphoria.hadoop.HadoopUtils;
+import cz.seznam.euphoria.hadoop.output.SequenceFileSink.SinkBuilder;
 import cz.seznam.euphoria.testing.DatasetAssert;
+import java.nio.file.Paths;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
@@ -33,80 +38,358 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.DeflateCodec;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.lib.input.KeyValueLineRecordReader;
+import org.apache.hadoop.mapreduce.lib.input.LineRecordReader;
 import org.apache.hadoop.mapreduce.lib.input.SequenceFileRecordReader;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class HadoopSinkTest {
+/**
+ * Tests {@link HadoopSink} implementations. Each implementation is tested with and without {@link
+ * org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat} to see whether it produces empty result
+ * files (with {@link org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat} no empty files should
+ * be created).
+ *
+ * @param <I> type of objects in data source (input)
+ * @param <O> type of objects in output
+ * @param <S> data source type
+ * @param <T> data sink (output) type
+ */
+@RunWith(Parameterized.class)
+public class HadoopSinkTest<I, O, S extends DataSource<I>, T extends DataSink<I>> {
 
-  @Rule
-  public TemporaryFolder tmp = new TemporaryFolder();
+  @Parameters(name = "{index}: {0}")
+  public static List<Object[]> testParameters() {
+    return Arrays.asList(
+        new Object[][] {
+          // DataSinkTester, useLazyOutputFormat, expectedNumberOfReduceOutputs
+          {"SequenceFileSink", new SequenceFileSinkTester(), false, 5},
+          {"SequenceFileSink - lazy", new SequenceFileSinkTester(), true, 4},
+          {"HadoopTextFileSink", new HadoopTextFileSinkTester(), false, 5},
+          {"HadoopTextFileSink - lazy", new HadoopTextFileSinkTester(), true, 4},
+          {"SimpleHadoopTextFileSink", new SimpleHadoopTextFileSinkTester(), false, 5},
+          {"SimpleHadoopTextFileSink - lazy", new SimpleHadoopTextFileSinkTester(), true, 4},
+          {"HadoopToStringSink", new HadoopToStringSinkTester(), false, 5},
+          {"HadoopToStringSink - lazy", new HadoopToStringSinkTester(), true, 4}
+        });
+  }
+
+  private final String testName;
+  private final DataSinkTester<I, O, S, T> dataSinkTester;
+  private final boolean useLazyOutputFormat;
+  private final int expectedNumberOfReduceOutputs;
+
+  public HadoopSinkTest(
+      String testName,
+      DataSinkTester<I, O, S, T> dataSinkTester,
+      boolean useLazyOutputFormat,
+      int expectedNumberOfReduceOutputs) {
+    this.testName = testName;
+    this.dataSinkTester = dataSinkTester;
+    this.useLazyOutputFormat = useLazyOutputFormat;
+    this.expectedNumberOfReduceOutputs = expectedNumberOfReduceOutputs;
+  }
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
   @Test
-  public void test() throws InterruptedException, IOException {
+  public void test() {
+    final Configuration conf = new Configuration();
 
-    final String outputDir = tmp.getRoot() + "/output";
+    final String outputDir =
+        Paths.get(tmp.getRoot().getAbsolutePath(), testName).toAbsolutePath().toString();
 
     final Flow flow = Flow.create();
 
-    final DataSource<Pair<Text, LongWritable>> source = ListDataSource.bounded(
-        Collections.singletonList(Pair.of(new Text("first"), new LongWritable(1L))),
-        Collections.singletonList(Pair.of(new Text("second"), new LongWritable(2L))),
-        Collections.singletonList(Pair.of(new Text("third"), new LongWritable(3L))),
-        Collections.singletonList(Pair.of(new Text("fourth"), new LongWritable(3L))));
+    final S source = dataSinkTester.prepareDataSource();
+    final T sink = dataSinkTester.buildSink(outputDir, conf, useLazyOutputFormat);
 
-    final HadoopSink<Text, LongWritable> sink =  SequenceFileSink.of(Text.class, LongWritable.class)
-        .outputPath(outputDir)
-        .withCompression(DeflateCodec.class, SequenceFile.CompressionType.BLOCK)
-        .build();
-
-    MapElements
-        .of(flow.createInput(source))
-        .using(p -> p)
-        .output()
-        .persist(sink);
+    MapElements.of(flow.createInput(source)).using(p -> p).output().persist(sink);
 
     final Executor executor = new LocalExecutor().setDefaultParallelism(4);
     executor.submit(flow).join();
 
     String[] files = new File(outputDir).list();
     assertNotNull(files);
-    final List<Pair<Text, LongWritable>> output = Arrays.stream(files)
-        .filter(file -> file.startsWith("part-r-"))
-        .flatMap(part -> ExceptionUtils.unchecked(() -> {
-          try (final SequenceFileRecordReader<Text, LongWritable> reader =
-                   new SequenceFileRecordReader<>()) {
-            final Path path = new Path(outputDir + "/" + part);
-            final TaskAttemptContext taskContext =
-                HadoopUtils.createTaskContext(new Configuration(), HadoopUtils.getJobID(), 0);
-            reader.initialize(
-                new FileSplit(path, 0L, Long.MAX_VALUE, new String[]{"localhost"}),
-                taskContext);
-            final List<Pair<Text, LongWritable>> result = new ArrayList<>();
-            while (reader.nextKeyValue()) {
-              result.add(Pair.of(reader.getCurrentKey(), reader.getCurrentValue()));
-            }
-            return result.stream();
-          }
-        }))
-        .collect(Collectors.toList());
 
-    DatasetAssert.unorderedEquals(Arrays.asList(
-        Pair.of(new Text("first"), new LongWritable(1L)),
-        Pair.of(new Text("second"), new LongWritable(2L)),
-        Pair.of(new Text("third"), new LongWritable(3L)),
-        Pair.of(new Text("fourth"), new LongWritable(3L))
-    ), output);
+    List<String> reduceOutputFileNames =
+        Arrays.stream(files)
+            .filter(file -> file.startsWith("part-r-"))
+            .collect(Collectors.toList());
+    assertEquals(expectedNumberOfReduceOutputs, reduceOutputFileNames.size());
+
+    final List<O> output =
+        reduceOutputFileNames
+            .stream()
+            .flatMap(dataSinkTester.extractOutputFunction(outputDir, conf))
+            .collect(Collectors.toList());
+
+    DatasetAssert.unorderedEquals(dataSinkTester.expectedOutput(), output);
   }
 
+  /**
+   * Helper interface for parameterized tests.
+   *
+   * @param <I> type of objects in data source (input)
+   * @param <O> type of objects in output
+   * @param <S> data source type
+   * @param <T> data sink (output) type
+   */
+  private interface DataSinkTester<I, O, S extends DataSource<I>, T extends DataSink<I>> {
+
+    /** builds/creates desired output sink */
+    T buildSink(String outputDir, Configuration conf, boolean useLazyOutputFormat);
+
+    /** builds/creates desired input source (data source) */
+    S prepareDataSource();
+
+    /**
+     * returns function which loads created file, reads its content a creates desired output stream
+     * out of the content
+     */
+    Function<String, Stream<O>> extractOutputFunction(String outputDir, Configuration conf);
+
+    /**
+     * returns expected output which is then compared with result from {@link
+     * #extractOutputFunction(String, Configuration)}
+     */
+    List<O> expectedOutput();
+  }
+
+  private static class SequenceFileSinkTester
+      implements DataSinkTester<
+          Pair<Text, LongWritable>,
+          Pair<Text, LongWritable>,
+          DataSource<Pair<Text, LongWritable>>,
+          SequenceFileSink<Text, LongWritable>> {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public SequenceFileSink<Text, LongWritable> buildSink(
+        String outputDir, Configuration conf, boolean useLazyOutputFormat) {
+      SinkBuilder<Text, LongWritable> sinkBuilder =
+          SequenceFileSink.of(Text.class, LongWritable.class)
+              .outputPath(outputDir)
+              .withConfiguration(conf)
+              .withCompression(DeflateCodec.class, SequenceFile.CompressionType.BLOCK);
+      if (useLazyOutputFormat) {
+        sinkBuilder = sinkBuilder.withLazyOutputFormat();
+      }
+      return sinkBuilder.build();
+    }
+
+    @Override
+    public DataSource<Pair<Text, LongWritable>> prepareDataSource() {
+      return ListDataSource.bounded(
+          Collections.singletonList(Pair.of(new Text("first"), new LongWritable(1L))),
+          Collections.singletonList(Pair.of(new Text("second"), new LongWritable(2L))),
+          Collections.singletonList(Pair.of(new Text("third"), new LongWritable(3L))),
+          Collections.singletonList(Pair.of(new Text("fourth"), new LongWritable(3L))),
+          Collections.emptyList());
+    }
+
+    @Override
+    public Function<String, Stream<Pair<Text, LongWritable>>> extractOutputFunction(
+        String outputDir, Configuration conf) {
+      return part ->
+          ExceptionUtils.unchecked(
+              () -> {
+                try (final SequenceFileRecordReader<Text, LongWritable> reader =
+                    new SequenceFileRecordReader<>()) {
+                  final Path path = new Path(outputDir + "/" + part);
+                  final TaskAttemptContext taskContext =
+                      HadoopUtils.createTaskContext(new Configuration(), HadoopUtils.getJobID(), 0);
+                  reader.initialize(
+                      new FileSplit(path, 0L, Long.MAX_VALUE, new String[] {"localhost"}),
+                      taskContext);
+                  final List<Pair<Text, LongWritable>> result = new ArrayList<>();
+                  while (reader.nextKeyValue()) {
+                    result.add(Pair.of(reader.getCurrentKey(), reader.getCurrentValue()));
+                  }
+                  return result.stream();
+                }
+              });
+    }
+
+    @Override
+    public List<Pair<Text, LongWritable>> expectedOutput() {
+      return Arrays.asList(
+          Pair.of(new Text("first"), new LongWritable(1L)),
+          Pair.of(new Text("second"), new LongWritable(2L)),
+          Pair.of(new Text("third"), new LongWritable(3L)),
+          Pair.of(new Text("fourth"), new LongWritable(3L)));
+    }
+  }
+
+  private static class HadoopTextFileSinkTester
+      implements DataSinkTester<
+          Pair<Text, LongWritable>,
+          Pair<String, Long>,
+          DataSource<Pair<Text, LongWritable>>,
+          HadoopTextFileSink<Text, LongWritable>> {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public HadoopTextFileSink<Text, LongWritable> buildSink(
+        String outputDir, Configuration conf, boolean useLazyOutputFormat) {
+      return new HadoopTextFileSink<>(outputDir, conf, useLazyOutputFormat);
+    }
+
+    @Override
+    public DataSource<Pair<Text, LongWritable>> prepareDataSource() {
+      return ListDataSource.bounded(
+          Collections.singletonList(Pair.of(new Text("first"), new LongWritable(1L))),
+          Collections.singletonList(Pair.of(new Text("second"), new LongWritable(2L))),
+          Collections.singletonList(Pair.of(new Text("third"), new LongWritable(3L))),
+          Collections.singletonList(Pair.of(new Text("fourth"), new LongWritable(3L))),
+          Collections.emptyList());
+    }
+
+    @Override
+    public Function<String, Stream<Pair<String, Long>>> extractOutputFunction(
+        String outputDir, Configuration conf) {
+      return part ->
+          ExceptionUtils.unchecked(
+              () -> {
+                try (final KeyValueLineRecordReader reader = new KeyValueLineRecordReader(conf)) {
+                  final Path path = new Path(outputDir + "/" + part);
+                  final TaskAttemptContext taskContext =
+                      HadoopUtils.createTaskContext(new Configuration(), HadoopUtils.getJobID(), 0);
+                  reader.initialize(
+                      new FileSplit(path, 0L, Long.MAX_VALUE, new String[] {"localhost"}),
+                      taskContext);
+                  final List<Pair<String, Long>> result = new ArrayList<>();
+                  while (reader.nextKeyValue()) {
+                    result.add(
+                        Pair.of(
+                            reader.getCurrentKey().toString(),
+                            Long.valueOf(reader.getCurrentValue().toString())));
+                  }
+                  return result.stream();
+                }
+              });
+    }
+
+    @Override
+    public List<Pair<String, Long>> expectedOutput() {
+      return Arrays.asList(
+          Pair.of("first", 1L), Pair.of("second", 2L), Pair.of("third", 3L), Pair.of("fourth", 3L));
+    }
+  }
+
+  private static class SimpleHadoopTextFileSinkTester
+      implements DataSinkTester<Text, String, DataSource<Text>, SimpleHadoopTextFileSink<Text>> {
+
+    @Override
+    public SimpleHadoopTextFileSink<Text> buildSink(
+        String outputDir, Configuration conf, boolean useLazyOutputFormat) {
+      return new SimpleHadoopTextFileSink<>(outputDir, conf, useLazyOutputFormat);
+    }
+
+    @Override
+    public DataSource<Text> prepareDataSource() {
+      return ListDataSource.bounded(
+          Collections.singletonList(new Text("first")),
+          Collections.singletonList(new Text("second")),
+          Collections.singletonList(new Text("third")),
+          Collections.singletonList(new Text("fourth")),
+          Collections.emptyList());
+    }
+
+    @Override
+    public Function<String, Stream<String>> extractOutputFunction(
+        String outputDir, Configuration conf) {
+      return part ->
+          ExceptionUtils.unchecked(
+              () -> {
+                try (final LineRecordReader reader = new LineRecordReader()) {
+                  final Path path = new Path(outputDir + "/" + part);
+                  final TaskAttemptContext taskContext =
+                      HadoopUtils.createTaskContext(new Configuration(), HadoopUtils.getJobID(), 0);
+                  reader.initialize(
+                      new FileSplit(path, 0L, Long.MAX_VALUE, new String[] {"localhost"}),
+                      taskContext);
+                  final List<String> result = new ArrayList<>();
+                  while (reader.nextKeyValue()) {
+                    result.add(reader.getCurrentValue().toString());
+                  }
+                  return result.stream();
+                }
+              });
+    }
+
+    @Override
+    public List<String> expectedOutput() {
+      return Arrays.asList("first", "second", "third", "fourth");
+    }
+  }
+
+  private static class HadoopToStringSinkTester
+      implements DataSinkTester<
+          Pair<String, String>,
+          String,
+          DataSource<Pair<String, String>>,
+          HadoopToStringSink<Pair<String, String>>> {
+
+    @Override
+    public HadoopToStringSink<Pair<String, String>> buildSink(
+        String outputDir, Configuration conf, boolean useLazyOutputFormat) {
+      return new HadoopToStringSink<>(outputDir, conf, useLazyOutputFormat);
+    }
+
+    @Override
+    public DataSource<Pair<String, String>> prepareDataSource() {
+      return ListDataSource.bounded(
+          Collections.singletonList(Pair.of("first", "1")),
+          Collections.singletonList(Pair.of("second", "2")),
+          Collections.singletonList(Pair.of("third", "3")),
+          Collections.singletonList(Pair.of("fourth", "4")),
+          Collections.emptyList());
+    }
+
+    @Override
+    public Function<String, Stream<String>> extractOutputFunction(
+        String outputDir, Configuration conf) {
+      return part ->
+          ExceptionUtils.unchecked(
+              () -> {
+                try (final LineRecordReader reader = new LineRecordReader()) {
+                  final Path path = new Path(outputDir + "/" + part);
+                  final TaskAttemptContext taskContext =
+                      HadoopUtils.createTaskContext(new Configuration(), HadoopUtils.getJobID(), 0);
+                  reader.initialize(
+                      new FileSplit(path, 0L, Long.MAX_VALUE, new String[] {"localhost"}),
+                      taskContext);
+                  final List<String> result = new ArrayList<>();
+                  while (reader.nextKeyValue()) {
+                    result.add(reader.getCurrentValue().toString());
+                  }
+                  return result.stream();
+                }
+              });
+    }
+
+    @Override
+    public List<String> expectedOutput() {
+      return Arrays.asList(
+          Pair.of("first", "1").toString(),
+          Pair.of("second", "2").toString(),
+          Pair.of("third", "3").toString(),
+          Pair.of("fourth", "4").toString());
+    }
+  }
 }


### PR DESCRIPTION
`LazyOutputFormat` doesn't create empty files (`part-m-XXXX`, `part-r-XXXX`)