### PR TITLE
named-outputvalues

### DIFF
--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Builders.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Builders.java
@@ -108,9 +108,10 @@ public class Builders {
      * @return the dataset representing the new operator's output
      */
     default Dataset<V> outputValues(OutputHint... outputHints) {
+      Dataset<Pair<K, V>> out = output();
       return MapElements
-          .named("extract-values")
-          .of(output())
+          .named((out.getProducer() == null ? "" : out.getProducer().getName()) + "-values")
+          .of(out)
           .using(Pair::getSecond)
           .output(outputHints);
     }

--- a/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Builders.java
+++ b/euphoria-core/src/main/java/cz/seznam/euphoria/core/client/operator/Builders.java
@@ -110,7 +110,8 @@ public class Builders {
     default Dataset<V> outputValues(OutputHint... outputHints) {
       Dataset<Pair<K, V>> out = output();
       return MapElements
-          .named((out.getProducer() == null ? "" : out.getProducer().getName()) + "-values")
+          .named(out.getProducer() == null ? "extract-values"
+              : out.getProducer().getName() + "-values")
           .of(out)
           .using(Pair::getSecond)
           .output(outputHints);


### PR DESCRIPTION
Derive operator/dataset name from previous operation, so datasets in "Storage" tab on Spark historyserver will have more useful names instead of "extract-values".